### PR TITLE
allow ignoring files on create using .createconfig

### DIFF
--- a/src/commands/create/create-config.js
+++ b/src/commands/create/create-config.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+exports.applyConfigInDirectory = function(directoryPath, packageData) {
+    let createConfig = getCreateConfig(directoryPath);
+    let createIgnore = createConfig.ignore || {};
+    let ignoredFiles = createIgnore.files;
+    let ignoredScripts = createIgnore.scripts;
+    let ignoredDependencies = createIgnore.dependencies;
+
+    if (ignoredScripts && packageData.scripts) {
+        removeKeys(packageData, 'scripts', ignoredScripts);
+    }
+
+    if (ignoredDependencies) {
+        if (packageData.dependencies) {
+            removeKeys(packageData, 'dependencies', ignoredDependencies);
+        }
+        if (packageData.devDependencies) {
+            removeKeys(packageData, 'devDependencies', ignoredDependencies);
+        }
+    }
+
+    if (ignoredFiles) {
+        ignoredFiles.forEach(file => {
+            fs.unlinkSync(path.resolve(directoryPath, file));
+        });
+    }
+}
+
+function getCreateConfig(directoryPath) {
+    let createConfigPath = path.resolve(directoryPath, '.createconfig');
+    let createConfigRaw = fs.existsSync(createConfigPath) && fs.readFileSync(createConfigPath, 'utf8');
+    let createConfig = createConfigRaw ? JSON.parse(createConfigRaw) : {};
+    return createConfig;
+}
+
+function removeKeys(parent, prop, propsToRemove) {
+    let object = parent[prop];
+    propsToRemove.forEach(propName => {
+        delete object[propName];
+    });
+    if (Object.keys(object).length === 0) {
+        delete parent[prop];
+    }
+}


### PR DESCRIPTION
Allows a project template's repo to include certain files in the repo, but not have them copied when the user creates a new project using `marko create`.

**`.createconfig`**
```json
{
  "ignore": {
    "files": [".travis.yml"]
  }
}
```

Also supports `ignore.dependencies` and `ignore.scripts`.