### PR TITLE
Prettyprint: parse with placeholders and fix printing of nodes

### DIFF
--- a/packages/prettyprint/package-lock.json
+++ b/packages/prettyprint/package-lock.json
@@ -1,0 +1,420 @@
+{
+	"name": "@marko/prettyprint",
+	"version": "1.1.3",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"marko": {
+			"version": "4.14.3",
+			"resolved": "https://registry.npmjs.org/marko/-/marko-4.14.3.tgz",
+			"integrity": "sha512-YxtHQE6+mFqTICxvWbMtCVz7w0rCsg0LuisKRodcB8iYD2KT6SFoBsl8hrjKMpQIWo5CVnxxdd/Cq/eOwlE+wg==",
+			"requires": {
+				"app-module-path": "^2.2.0",
+				"argly": "^1.0.0",
+				"browser-refresh-client": "^1.0.0",
+				"char-props": "~0.1.5",
+				"complain": "^1.3.0",
+				"deresolve": "^1.1.2",
+				"escodegen": "^1.8.1",
+				"esprima": "^4.0.0",
+				"estraverse": "^4.2.0",
+				"events": "^1.0.2",
+				"events-light": "^1.0.0",
+				"he": "^1.1.0",
+				"htmljs-parser": "^2.5.0",
+				"lasso-caching-fs": "^1.0.1",
+				"lasso-modules-client": "^2.0.4",
+				"lasso-package-root": "^1.0.1",
+				"listener-tracker": "^2.0.0",
+				"minimatch": "^3.0.2",
+				"object-assign": "^4.1.0",
+				"property-handlers": "^1.0.0",
+				"raptor-json": "^1.0.1",
+				"raptor-polyfill": "^1.0.0",
+				"raptor-promises": "^1.0.1",
+				"raptor-regexp": "^1.0.0",
+				"raptor-util": "^3.2.0",
+				"resolve-from": "^2.0.0",
+				"shorthash": "0.0.2",
+				"simple-sha1": "^2.1.0",
+				"strip-json-comments": "^2.0.1",
+				"try-require": "^1.2.1",
+				"warp10": "^1.0.0"
+			},
+			"dependencies": {
+				"app-module-path": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+					"integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
+				},
+				"argly": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/argly/-/argly-1.2.0.tgz",
+					"integrity": "sha1-KydORVGin/XnGZ0u2XiOtm7TbmA="
+				},
+				"assertion-error": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+					"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"browser-refresh-client": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/browser-refresh-client/-/browser-refresh-client-1.1.4.tgz",
+					"integrity": "sha1-jl/4R1/h1UHSroH3oa6gWuIaYhc="
+				},
+				"chai": {
+					"version": "3.5.0",
+					"resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+					"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+					"requires": {
+						"assertion-error": "^1.0.1",
+						"deep-eql": "^0.1.3",
+						"type-detect": "^1.0.0"
+					}
+				},
+				"char-props": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/char-props/-/char-props-0.1.5.tgz",
+					"integrity": "sha1-W5UvniDqIc0Iyn/hNaEPb+kcEJ4="
+				},
+				"complain": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/complain/-/complain-1.3.0.tgz",
+					"integrity": "sha512-PA9uGpaS4BXKrhFx3rl2nZMWySnGoW1pWf+dpBqNdDx3uR6PA0EPxjD17H9OxvW5w/bODBSziQ516Guf59rW+w==",
+					"requires": {
+						"error-stack-parser": "^2.0.1"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+				},
+				"deep-eql": {
+					"version": "0.1.3",
+					"resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+					"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+					"requires": {
+						"type-detect": "0.1.1"
+					},
+					"dependencies": {
+						"type-detect": {
+							"version": "0.1.1",
+							"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+							"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+						}
+					}
+				},
+				"deep-is": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+					"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+				},
+				"deresolve": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/deresolve/-/deresolve-1.1.2.tgz",
+					"integrity": "sha1-nPI3nI0tYx3EuZVylLkOSnLLbOA=",
+					"requires": {
+						"lasso-package-root": "^1.0.0",
+						"raptor-polyfill": "^1.0.2",
+						"resolve-from": "^1.0.1"
+					},
+					"dependencies": {
+						"resolve-from": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+							"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+						}
+					}
+				},
+				"error-stack-parser": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
+					"integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
+					"requires": {
+						"stackframe": "^1.0.4"
+					}
+				},
+				"escodegen": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+					"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+					"requires": {
+						"esprima": "^3.1.3",
+						"estraverse": "^4.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
+					},
+					"dependencies": {
+						"esprima": {
+							"version": "3.1.3",
+							"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+							"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+						}
+					}
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+				},
+				"estraverse": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+					"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+				},
+				"events": {
+					"version": "1.1.1",
+					"resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+				},
+				"events-light": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/events-light/-/events-light-1.0.5.tgz",
+					"integrity": "sha1-lk5jRQugr0prAiqpVbF//vZXte4=",
+					"requires": {
+						"chai": "^3.5.0"
+					}
+				},
+				"fast-levenshtein": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+					"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+				},
+				"he": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+					"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+				},
+				"htmljs-parser": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.5.0.tgz",
+					"integrity": "sha512-1P/WMHVYA+hZdVPmkwlvzBR/rp/VDX4X41Jyd94NpSz9l4QH5V8sOIXdtpLbUdvgI2IucpITIflW7iLgL5oKkA==",
+					"requires": {
+						"char-props": "^0.1.5",
+						"complain": "^1.0.0"
+					}
+				},
+				"lasso-caching-fs": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/lasso-caching-fs/-/lasso-caching-fs-1.0.2.tgz",
+					"integrity": "sha1-m+TrHwaqwSYDRMrq70LC8AhusQ0=",
+					"requires": {
+						"raptor-async": "^1.1.2"
+					}
+				},
+				"lasso-modules-client": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/lasso-modules-client/-/lasso-modules-client-2.0.5.tgz",
+					"integrity": "sha1-2aBnJKkAl3Y2lxZn7pwXDS/E3Sg=",
+					"requires": {
+						"lasso-package-root": "^1.0.0",
+						"raptor-polyfill": "^1.0.2"
+					}
+				},
+				"lasso-package-root": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/lasso-package-root/-/lasso-package-root-1.0.1.tgz",
+					"integrity": "sha1-mX0OcfQdA8Xw+gmlvCmNeW+LLCM=",
+					"requires": {
+						"lasso-caching-fs": "^1.0.0"
+					}
+				},
+				"levn": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+					"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+					"requires": {
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2"
+					}
+				},
+				"listener-tracker": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/listener-tracker/-/listener-tracker-2.0.0.tgz",
+					"integrity": "sha1-OWCLQ1wJAfpVECF8FFJyjWvBm18="
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"optionator": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+					"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+					"requires": {
+						"deep-is": "~0.1.3",
+						"fast-levenshtein": "~2.0.4",
+						"levn": "~0.3.0",
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2",
+						"wordwrap": "~1.0.0"
+					}
+				},
+				"prelude-ls": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+				},
+				"property-handlers": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/property-handlers/-/property-handlers-1.1.1.tgz",
+					"integrity": "sha1-yyDTIqq32U//rCj0bJGGvVlHtLQ="
+				},
+				"q": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+					"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+				},
+				"raptor-async": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/raptor-async/-/raptor-async-1.1.3.tgz",
+					"integrity": "sha1-uDw8m2A9yYXCw6n3jStAc+b2Akw="
+				},
+				"raptor-json": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/raptor-json/-/raptor-json-1.1.0.tgz",
+					"integrity": "sha1-cL0JsU5k99MuxQzOg3fWApwPCHY=",
+					"requires": {
+						"raptor-strings": "^1.0.0"
+					}
+				},
+				"raptor-polyfill": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/raptor-polyfill/-/raptor-polyfill-1.1.0.tgz",
+					"integrity": "sha512-VhFc5e6EuNGdax7FQ2QWlCdXFi5OBBsclDh0kzZtgBI7lauc8aFs7+htdi5Q3qCRoYXfsucSBsRKf7a3s+YGmA=="
+				},
+				"raptor-promises": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/raptor-promises/-/raptor-promises-1.0.3.tgz",
+					"integrity": "sha1-1XaxEOBCNlT3/fFyHijULk3DwOs=",
+					"requires": {
+						"q": "^1.0.1",
+						"raptor-util": "^1.0.0"
+					},
+					"dependencies": {
+						"raptor-util": {
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-1.1.2.tgz",
+							"integrity": "sha1-8u6AdqmuPq4uZWcuRqIgB0+i3/M="
+						}
+					}
+				},
+				"raptor-regexp": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/raptor-regexp/-/raptor-regexp-1.0.1.tgz",
+					"integrity": "sha1-7PD2bGZxwM2fXkjDcFAmxVCZlcA="
+				},
+				"raptor-strings": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/raptor-strings/-/raptor-strings-1.0.2.tgz",
+					"integrity": "sha1-ks4ssBU6/pBHDYA5oCVbTPM6tfw=",
+					"requires": {
+						"raptor-polyfill": "^1.0.1"
+					}
+				},
+				"raptor-util": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-3.2.0.tgz",
+					"integrity": "sha1-I7DIA8jxrIocrmfZpjiLSRYcl1g="
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+				},
+				"rusha": {
+					"version": "0.8.13",
+					"resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.13.tgz",
+					"integrity": "sha1-mghOe4YLF7/zAVuSxnpqM2GRUTo="
+				},
+				"shorthash": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/shorthash/-/shorthash-0.0.2.tgz",
+					"integrity": "sha1-WbJo7sveWQOLMNogK8+93rLEpOs="
+				},
+				"simple-sha1": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.1.tgz",
+					"integrity": "sha512-pFMPd+I/lQkpf4wFUeS/sED5IqdIG1lUlrQviBMV4u4mz8BRAcB5fvUx5Ckfg3kBigEglAjHg7E9k/yy2KlCqA==",
+					"requires": {
+						"rusha": "^0.8.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"optional": true
+				},
+				"stackframe": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
+					"integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+				},
+				"try-require": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/try-require/-/try-require-1.2.1.tgz",
+					"integrity": "sha1-NEiaLKwMCcHMEO2RugEVlNQzO+I="
+				},
+				"type-check": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+					"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+					"requires": {
+						"prelude-ls": "~1.1.2"
+					}
+				},
+				"type-detect": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+					"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+				},
+				"warp10": {
+					"version": "1.3.6",
+					"resolved": "https://registry.npmjs.org/warp10/-/warp10-1.3.6.tgz",
+					"integrity": "sha512-7cijX+NprqPV+UGUZXZw1I15JFHPqoy65tNVvP6cL43Vlanpcm8hBYoQTuDYUHa5x90Bct4gHhRtqqOOkLhQkw=="
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				}
+			}
+		}
+	}
+}

--- a/packages/prettyprint/package.json
+++ b/packages/prettyprint/package.json
@@ -8,7 +8,7 @@
     "argly": "^1.2.0",
     "editorconfig": "^0.15.2",
     "lasso-package-root": "^1.0.1",
-    "marko": "^4.14.2",
+    "marko": "^4.14.3",
     "minimatch": "^3.0.4",
     "prettier": "^1.15.3",
     "redent": "^2.0.0",

--- a/packages/prettyprint/src/prettyPrintSource.js
+++ b/packages/prettyprint/src/prettyPrintSource.js
@@ -28,6 +28,6 @@ module.exports = function prettyPrintSource(src, options) {
   options.CodeWriter =
     options.CodeWriter || requireMarkoFile(dirname, "compiler/CodeWriter");
 
-  var ast = markoCompiler.parseRaw(src, filename);
+  var ast = markoCompiler.parse(src, filename, { raw: true });
   return prettyPrintAST(ast, options);
 };

--- a/packages/prettyprint/src/printHtmlElement.js
+++ b/packages/prettyprint/src/printHtmlElement.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const unescapePlaceholdersInStringExpression = require("./util/unescapePlaceholdersInStringExpression");
 const hasUnenclosedWhitespace = require("./util/hasUnenclosedWhitespace");
 const getBodyText = require("./util/getBodyText");
 const hasLineBreaks = require("./util/hasLineBreaks");
@@ -162,10 +161,9 @@ module.exports = function printHtmlElement(node, printContext, writer) {
       attrStr += attr.name;
       if (attrValueStr) {
         if (hasUnenclosedWhitespace(attr.value)) {
-          attrStr +=
-            "=(" + unescapePlaceholdersInStringExpression(attrValueStr) + ")";
+          attrStr += "=(" + attrValueStr + ")";
         } else {
-          attrStr += "=" + unescapePlaceholdersInStringExpression(attrValueStr);
+          attrStr += "=" + attrValueStr;
         }
       } else if (attr.argument != null) {
         attrStr +=

--- a/packages/prettyprint/src/printHtmlElement.js
+++ b/packages/prettyprint/src/printHtmlElement.js
@@ -102,11 +102,11 @@ module.exports = function printHtmlElement(node, printContext, writer) {
     writer.write("<");
   }
 
-  if (tagNameExpression) {
-    writer.write(`\${${tagNameExpression}}`);
-  } else {
-    writer.write(node.tagName);
-  }
+  var tagNameString = tagNameExpression
+    ? `\${${formatJS(tagNameExpression, printContext, undefined, true)}}`
+    : node.tagName;
+
+  writer.write(tagNameString);
 
   if (node.rawShorthandId) {
     writer.write("#" + node.rawShorthandId);
@@ -114,7 +114,13 @@ module.exports = function printHtmlElement(node, printContext, writer) {
 
   if (node.rawShorthandClassNames) {
     node.rawShorthandClassNames.forEach(className => {
-      writer.write("." + className);
+      if (typeof className === "string") {
+        writer.write("." + className);
+      } else {
+        writer.write(
+          ".${" + toCode(className, printContext, undefined, true) + "}"
+        );
+      }
     });
   }
 
@@ -131,7 +137,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
 
   var hasBody = node.body && node.body.length;
 
-  let bodyText = getBodyText(node);
+  let bodyText = getBodyText(node, printContext);
   if (bodyText && printContext.preserveWhitespace !== true) {
     bodyText = bodyText.trim();
   }
@@ -143,7 +149,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
 
   // We will make one pass to generate all of the strings for each attribute. We will then
   // append them to the output while avoiding putting too many attributes on one line.
-  attrs.forEach((attr, i) => {
+  attrs.forEach(attr => {
     var attrStr = "";
     var attrValueStr = toCode(
       attr.value,
@@ -231,7 +237,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
           });
         } else {
           writer.write(" [" + printContext.eol);
-          attrStringsArray.forEach((attrString, i) => {
+          attrStringsArray.forEach(attrString => {
             writer.write(printContext.currentIndentString);
             writer.write(printContext.indentString);
             writer.write(printContext.indentString);
@@ -259,7 +265,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
     return;
   }
 
-  var endTag = printContext.isHtmlSyntax ? "</" + node.tagName + ">" : "";
+  var endTag = printContext.isHtmlSyntax ? "</" + tagNameString + ">" : "";
 
   if (bodyText && !hasLineBreaks(bodyText)) {
     let endCol = writer.col + bodyText.length + endTag.length;
@@ -268,7 +274,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
       if (printContext.isConciseSyntax) {
         writer.write(" -- " + bodyText);
       } else {
-        writer.write(bodyText + "</" + node.tagName + ">");
+        writer.write(bodyText + "</" + tagNameString + ">");
       }
       return;
     }

--- a/packages/prettyprint/src/printNodes.js
+++ b/packages/prettyprint/src/printNodes.js
@@ -117,8 +117,6 @@ module.exports = function printNodes(nodes, printContext, inputWriter) {
   }
 
   let prevChild;
-  let firstChild;
-  let prevElement;
 
   nodes.forEach((child, i) => {
     var childWriter = new Writer(writer.col);
@@ -143,8 +141,6 @@ module.exports = function printNodes(nodes, printContext, inputWriter) {
 
     var childOutput = childWriter.getOutput();
     if (childOutput.length) {
-      firstChild = child;
-
       if (
         printContext.isHtmlSyntax &&
         printContext.preserveWhitespace === true
@@ -158,7 +154,7 @@ module.exports = function printNodes(nodes, printContext, inputWriter) {
         writer.write(printContext.currentIndentString);
       }
 
-      writer.write(childOutput.trim());
+      writer.write(HTMLTrim(childOutput, child, prevChild));
 
       if (avoidLineBreaks) {
         if (
@@ -185,11 +181,6 @@ module.exports = function printNodes(nodes, printContext, inputWriter) {
       }
     }
     prevChild = child;
-    if (child.type === "HtmlElement") {
-      prevElement = child;
-    } else if (child.type != "Text") {
-      prevElement = null;
-    }
   });
 
   if (printContext.isHtmlSyntax && printContext.preserveWhitespace !== true) {
@@ -243,3 +234,25 @@ module.exports = function printNodes(nodes, printContext, inputWriter) {
     }
   }
 };
+
+function HTMLTrim(content, child, prevChild) {
+  var startWhitespace = /^\s*/.exec(content)[0];
+  var endWhitespace = /\s*$/.exec(content)[0];
+  content = content.slice(
+    startWhitespace.length,
+    -1 * endWhitespace.length || undefined
+  );
+  if (child.type === "Text") {
+    if (startWhitespace && prevChild && prevChild.type === "Text") {
+      content = " " + content;
+    }
+    if (
+      endWhitespace &&
+      child.nextSibling &&
+      child.nextSibling.type === "Text"
+    ) {
+      content += " ";
+    }
+  }
+  return content;
+}

--- a/packages/prettyprint/src/printText.js
+++ b/packages/prettyprint/src/printText.js
@@ -3,12 +3,9 @@
 var trimLinesStart = require("./util/trim").trimLinesStart;
 var trimLinesEnd = require("./util/trim").trimLinesEnd;
 var indentLines = require("./util/indent").indentLines;
-var toCode = require("./util/toCode");
+var getTextValue = require("./util/getTextValue");
 module.exports = function printText(node, printContext, writer) {
-  var text =
-    node.argument.type === "Literal"
-      ? node.argument.value
-      : `\${${toCode(node.argument, printContext, undefined, true)}}`;
+  var text = getTextValue(node, printContext);
 
   var isConciseSyntax =
     printContext.depth === 0 || printContext.isConciseSyntax;

--- a/packages/prettyprint/src/util/getBodyText.js
+++ b/packages/prettyprint/src/util/getBodyText.js
@@ -1,6 +1,8 @@
 "use strict";
 
-module.exports = function getBodyText(el) {
+var getTextValue = require("./getTextValue");
+
+module.exports = function getBodyText(el, printContext) {
   var children = el.body.items;
   var text = "";
   for (var i = 0; i < children.length; i++) {
@@ -8,7 +10,7 @@ module.exports = function getBodyText(el) {
     if (child.type !== "Text") {
       return null;
     }
-    text += child.argument.value;
+    text += getTextValue(child, printContext);
   }
   return text;
 };

--- a/packages/prettyprint/src/util/getTextValue.js
+++ b/packages/prettyprint/src/util/getTextValue.js
@@ -1,0 +1,14 @@
+var toCode = require("./toCode");
+
+module.exports = function getTextValue(text, printContext) {
+  return text.argument.type === "Literal"
+    ? text.escape
+      ? text.argument.value
+      : text.argument.value.replace(/\\|\$!?{/g, m => "\\" + m)
+    : `$${text.escape ? "" : "!"}{${toCode(
+        text.argument,
+        printContext,
+        undefined,
+        true
+      )}}`;
+};

--- a/packages/prettyprint/src/util/indent.js
+++ b/packages/prettyprint/src/util/indent.js
@@ -1,5 +1,6 @@
 "use strict";
 var rtrim = require("./trim").rtrim;
+var ltrim = require("./trim").ltrim;
 
 exports.indentCommentLines = function indentCommentLines(lines, printContext) {
   var currentIndentString = printContext.currentIndentString;
@@ -7,7 +8,7 @@ exports.indentCommentLines = function indentCommentLines(lines, printContext) {
 
   var indentedLines = [];
 
-  lines.forEach((line, i) => {
+  lines.forEach(line => {
     if (line.trim() === "") {
       return;
     }
@@ -37,24 +38,26 @@ exports.indentLines = function indentLines(lines, printContext) {
   let blockIndentation = null;
 
   return lines.map((line, i) => {
-    if (blockIndentation == null) {
+    var firstLine = i === 0;
+    var lastLine = i === lines.length - 1;
+
+    if (blockIndentation == null && !firstLine) {
       blockIndentation = line.match(/^\s*/)[0];
     }
 
     if (line.trim()) {
-      if (line.startsWith(blockIndentation)) {
-        line = line.substring(blockIndentation.length);
+      if (!firstLine) {
+        if (line.startsWith(blockIndentation)) {
+          line = line.substring(blockIndentation.length);
+          line = lastLine ? line : rtrim(line);
+        } else {
+          line = lastLine ? ltrim(line) : line.trim();
+        }
 
-        line = rtrim(line);
-      } else {
-        line = line.trim();
-      }
-
-      if (i !== 0) {
         line = currentIndentString + line;
       }
     } else {
-      line = "";
+      line = firstLine || lastLine ? " " : "";
     }
 
     return line;

--- a/packages/prettyprint/src/util/toCode.js
+++ b/packages/prettyprint/src/util/toCode.js
@@ -14,6 +14,25 @@ module.exports = (node, printContext, indent, expression) => {
 
   const writer = new CodeWriter({}, builder);
 
+  const _writeLiteral = writer.writeLiteral;
+  writer.writeLiteral = function(value) {
+    if (typeof value === "string") {
+      this.write(
+        JSON.stringify(value).replace(/\$!?{/g, m => "__%ESCAPE%__" + m)
+      );
+    } else {
+      _writeLiteral.apply(this, arguments);
+    }
+  };
   writer.write(node);
-  return formatJS(writer.getCode(), printContext, indent, expression);
+  writer.writeLiteral = _writeLiteral;
+
+  const formatted = formatJS(
+    writer.getCode(),
+    printContext,
+    indent,
+    expression
+  );
+
+  return formatted.replace(/__%ESCAPE%__/g, "\\");
 };

--- a/packages/prettyprint/src/util/unescapePlaceholdersInStringExpression.js
+++ b/packages/prettyprint/src/util/unescapePlaceholdersInStringExpression.js
@@ -1,5 +1,0 @@
-"use strict";
-
-module.exports = function unescapePlaceholdersInStringExpression(string) {
-  return string;
-};

--- a/packages/prettyprint/src/util/unescapePlaceholdersInStringExpression.js
+++ b/packages/prettyprint/src/util/unescapePlaceholdersInStringExpression.js
@@ -1,13 +1,5 @@
 "use strict";
 
 module.exports = function unescapePlaceholdersInStringExpression(string) {
-  return string.replace(/([\\]{2,4})?\$[!]?{/g, function(match) {
-    if (match.startsWith("\\\\\\\\")) {
-      return match.substring(2);
-    } else if (match.startsWith("\\\\")) {
-      return match.substring(1);
-    }
-
-    return match;
-  });
+  return string;
 };

--- a/packages/prettyprint/test/autotest/attr-template-literal/expected.marko
+++ b/packages/prettyprint/test/autotest/attr-template-literal/expected.marko
@@ -1,3 +1,3 @@
-<div data-foo="bar" data-bar=tag`thing`/>
+<div data-foo=`bar` data-bar=tag`thing`/>
 ~~~~~~~
-div data-foo="bar" data-bar=tag`thing`
+div data-foo=`bar` data-bar=tag`thing`

--- a/packages/prettyprint/test/autotest/dynamic-tag-name/expected.marko
+++ b/packages/prettyprint/test/autotest/dynamic-tag-name/expected.marko
@@ -1,10 +1,10 @@
 <for(element in blah)>
-    <${(element.foo)}>
+    <${element.foo}>
         <include("foo")/>
     </${element.foo}>
 </for>
 ~~~~~~~
 for(element in blah)
-    <${(element.foo)}>
+    <${element.foo}>
         <include("foo")/>
     </${element.foo}>

--- a/packages/prettyprint/test/autotest/placeholders-string-double-backslash/expected.marko
+++ b/packages/prettyprint/test/autotest/placeholders-string-double-backslash/expected.marko
@@ -1,3 +1,3 @@
-<div data-foo="\\${foo} \\$!{foo}"/>
+<div data-foo="\\${foo} \\${foo}"/>
 ~~~~~~~
-div data-foo="\\${foo} \\$!{foo}"
+div data-foo="\\${foo} \\${foo}"

--- a/packages/prettyprint/test/util/autotest.js
+++ b/packages/prettyprint/test/util/autotest.js
@@ -45,26 +45,16 @@ function autoTest(name, dir, run, options, done) {
       if (process.env.UPDATE_EXPECTED) {
         fs.writeFileSync(expectedPath, actual, { encoding: "utf8" });
       } else {
-        throw new Error(
-          'Unexpected output for "' +
-            name +
-            '":\nEXPECTED (' +
-            expectedPath +
-            "):\n---------\n" +
-            (isJSON ? expectedJSON : expected) +
-            "\n---------\nACTUAL (" +
-            actualPath +
-            "):\n---------\n" +
-            (isJSON ? actualJSON : actual) +
-            "\n---------"
-        );
+        throw e;
       }
     }
   }
 
   try {
     fs.unlinkSync(actualPath);
-  } catch (e) {}
+  } catch (e) {
+    /*ignore*/
+  }
 
   if (done) {
     // Async test
@@ -120,7 +110,9 @@ exports.scanDir = function(autoTestDir, run, options) {
     var pendingFiles;
     try {
       pendingFiles = fs.readdirSync(autoTestDir + "-pending");
-    } catch (e) {}
+    } catch (e) {
+      /*ignore*/
+    }
 
     if (pendingFiles) {
       pendingFiles.forEach(function(name) {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->

Uses the new `compiler.parse` api in Marko to parse with placeholders in the ast.  Updates the printing logic to handle these new nodes.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

The migration ast includes these nodes, so we need to be able to print them properly.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
