### PR TITLE
feat(migrate): provide ability to override prompts in programatic api

### DIFF
--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -56,9 +56,16 @@ npm install @marko/migrate
 ```javascript
 import fs from "fs";
 import migrate from "@marko/migrate";
+import { prompt } from "enquirer";
 
 migrate({
-  patterns: ["./components/**/*.marko"]
+  files: ["./components/**/*.marko"],
+  prompt(options) {
+    // This is used for "optional" migrations.
+    // By default the cli mode uses enquirer to prompt the user via cli.
+    // The programtic api does not come with this by default and can be overwritten.
+    return prompt(options);
+  }
 }).then(output => {
   // Output contains an object with all of the migrated component sources.
   console.log("migrated all files");

--- a/packages/migrate/src/cli.js
+++ b/packages/migrate/src/cli.js
@@ -1,4 +1,5 @@
 import fs from "mz/fs";
+import { prompt } from "enquirer";
 import markoMigrate from ".";
 
 export function parse(argv) {
@@ -63,9 +64,6 @@ export function parse(argv) {
     })
     .parse(argv);
 
-  options.patterns = options.files;
-  delete options.files;
-
   return options;
 }
 
@@ -77,6 +75,7 @@ export async function run(options, markoCli) {
     singleQuote: false,
     ignore: ["/node_modules", ".*"],
     dir: markoCli.cwd,
+    prompt,
     ...options
   };
 

--- a/packages/migrate/src/util/migrate-helper.js
+++ b/packages/migrate/src/util/migrate-helper.js
@@ -1,12 +1,11 @@
-import enquirer from "enquirer";
 export const AUTO_APPLY = Symbol("Auto Apply");
 
 const STORES = new WeakMap();
 
 export default class MigrateHelper {
-  constructor() {
+  constructor(prompt) {
     STORES.set(this, new Map());
-    Object.assign(this, enquirer);
+    this.prompt = options => Promise.resolve(prompt(options));
   }
 
   has(name) {

--- a/packages/migrate/test/index.test.js
+++ b/packages/migrate/test/index.test.js
@@ -8,8 +8,9 @@ describe("scope(migrate)", () => {
   autotest("fixtures", async ({ dir, test, snapshot }) => {
     test(async () => {
       const outputs = await migrate({
+        prompt() {},
         ignore: ["**/snapshot-*.*"],
-        patterns: [`${dir}/**/*.marko`]
+        files: [`${dir}/**/*.marko`]
       });
 
       snapshot(


### PR DESCRIPTION
## Description

Exposes a `prompt` option on the `migrate` programmatic api which enables mocking.
Also renames `patterns` option to `files`.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
