### PR TITLE
fix(test): ensure errors displayed on older versions of Marko

### DIFF
--- a/packages/test/src/util/browser-tests-runner/server.js
+++ b/packages/test/src/util/browser-tests-runner/server.js
@@ -16,7 +16,13 @@ exports.start = async (templateData, options) => {
   const pageTemplate = options.pageTemplate || defaultPageTemplate;
   const server = express()
     .use(require("lasso/middleware").serveStatic({ lasso: templateData.lasso }))
-    .get("/", (req, res) => res.marko(pageTemplate, templateData))
+    .get("/", (req, res) => {
+      const out = res.marko(pageTemplate, templateData);
+      // Adds error handler for versions of marko before: https://github.com/marko-js/marko/pull/1119
+      if (!out.stream.listeners("error").includes(req.next)) {
+        out.on("error", req.next);
+      }
+    })
     .listen(serverPort);
   const wss = engine.attach(server);
 


### PR DESCRIPTION
## Description

This checks to see if `res.marko` has added added the error propagation handler and if not adds it.

This is done automatically as of https://github.com/marko-js/marko/pull/1119 but this change ensures errors are displayed for older versions.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
