### PR TITLE
feat(migrate): update dependent paths when renaming files

### DIFF
--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -66,20 +66,18 @@ migrate({
     // The programtic api does not come with this by default and can be overwritten.
     return prompt(options);
   }
-}).then(output => {
+}).then(({ updated, moved }) => {
   // Output contains an object with all of the migrated component sources.
   console.log("migrated all files");
 
-  for (const file in output) {
-    // Save all outputs to disk.
+  for (const file in updated) {
+    // Save all updated files to disk.
+    fs.writeFileSync(file, output[file], "utf-8");
+  }
 
-    if (output[file] === null) {
-      // File was removed.
-      fs.unlinkSync(file);
-    } else {
-      // File was updated.
-      fs.writeFileSync(file, output[file], "utf-8");
-    }
+  for (const file in moved) {
+    // Update locations of moved files on disk.
+    fs.renameSync(file, moved[file]);
   }
 });
 ```

--- a/packages/migrate/package-lock.json
+++ b/packages/migrate/package-lock.json
@@ -1,0 +1,988 @@
+{
+  "name": "@marko/migrate",
+  "version": "1.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/core": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
+      "integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.2.2",
+        "@babel/helpers": "^7.2.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/template": "^7.2.2",
+        "@babel/traverse": "^7.2.2",
+        "@babel/types": "^7.2.2",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.10",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.2.tgz",
+      "integrity": "sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==",
+      "requires": {
+        "@babel/types": "^7.2.2",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.2.0.tgz",
+      "integrity": "sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==",
+      "requires": {
+        "@babel/template": "^7.1.2",
+        "@babel/traverse": "^7.1.5",
+        "@babel/types": "^7.2.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
+      "integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA=="
+    },
+    "@babel/runtime": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/types": "^7.2.2"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.2.2",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.2.3",
+        "@babel/types": "^7.2.2",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
+      }
+    },
+    "@babel/types": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
+      "integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@marko/migrate-v3-widget": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@marko/migrate-v3-widget/-/migrate-v3-widget-1.0.5.tgz",
+      "integrity": "sha512-0qhgUaeimM/1BLAEPD+GzStCIoTgpeZ8xG6Ril3Yxj1kFysG0bqfnTdW60VbPb7/kEEgKAPqh1PqiLQA1qb7sg==",
+      "requires": {
+        "@babel/core": "^7.1.5",
+        "@babel/traverse": "^7.1.6",
+        "mz": "^2.7.0",
+        "recast": "^0.16.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@marko/prettyprint": {
+      "version": "1.2.0",
+      "requires": {
+        "argly": "^1.2.0",
+        "editorconfig": "^0.15.2",
+        "lasso-package-root": "^1.0.1",
+        "marko": "^4.14.3",
+        "minimatch": "^3.0.4",
+        "prettier": "^1.15.3",
+        "redent": "^2.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.12.18",
+          "bundled": true
+        },
+        "@types/semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "argly": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "commander": {
+          "version": "2.19.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "editorconfig": {
+          "version": "0.15.2",
+          "bundled": true,
+          "requires": {
+            "@types/node": "^10.11.7",
+            "@types/semver": "^5.5.0",
+            "commander": "^2.19.0",
+            "lru-cache": "^4.1.3",
+            "semver": "^5.6.0",
+            "sigmund": "^1.0.1"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "lasso-caching-fs": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "raptor-async": "^1.1.2"
+          }
+        },
+        "lasso-package-root": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "lasso-caching-fs": "^1.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "marko": {
+          "version": "4.14.7",
+          "bundled": true,
+          "requires": {
+            "app-module-path": "^2.2.0",
+            "argly": "^1.0.0",
+            "browser-refresh-client": "^1.0.0",
+            "char-props": "~0.1.5",
+            "complain": "^1.3.0",
+            "deresolve": "^1.1.2",
+            "escodegen": "^1.8.1",
+            "esprima": "^4.0.0",
+            "estraverse": "^4.2.0",
+            "events": "^1.0.2",
+            "events-light": "^1.0.0",
+            "he": "^1.1.0",
+            "htmljs-parser": "^2.5.0",
+            "lasso-caching-fs": "^1.0.1",
+            "lasso-modules-client": "^2.0.4",
+            "lasso-package-root": "^1.0.1",
+            "listener-tracker": "^2.0.0",
+            "minimatch": "^3.0.2",
+            "object-assign": "^4.1.0",
+            "property-handlers": "^1.0.0",
+            "raptor-json": "^1.0.1",
+            "raptor-polyfill": "^1.0.0",
+            "raptor-promises": "^1.0.1",
+            "raptor-regexp": "^1.0.0",
+            "raptor-util": "^3.2.0",
+            "resolve-from": "^2.0.0",
+            "shorthash": "0.0.2",
+            "simple-sha1": "^2.1.0",
+            "strip-json-comments": "^2.0.1",
+            "try-require": "^1.2.1",
+            "warp10": "^1.0.0"
+          },
+          "dependencies": {
+            "app-module-path": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "argly": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "assertion-error": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "browser-refresh-client": {
+              "version": "1.1.4",
+              "bundled": true
+            },
+            "chai": {
+              "version": "3.5.0",
+              "bundled": true,
+              "requires": {
+                "assertion-error": "^1.0.1",
+                "deep-eql": "^0.1.3",
+                "type-detect": "^1.0.0"
+              }
+            },
+            "char-props": {
+              "version": "0.1.5",
+              "bundled": true
+            },
+            "complain": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "error-stack-parser": "^2.0.1"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "deep-eql": {
+              "version": "0.1.3",
+              "bundled": true,
+              "requires": {
+                "type-detect": "0.1.1"
+              },
+              "dependencies": {
+                "type-detect": {
+                  "version": "0.1.1",
+                  "bundled": true
+                }
+              }
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "deresolve": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "lasso-package-root": "^1.0.0",
+                "raptor-polyfill": "^1.0.2",
+                "resolve-from": "^1.0.1"
+              },
+              "dependencies": {
+                "resolve-from": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "error-stack-parser": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "stackframe": "^1.0.4"
+              }
+            },
+            "escodegen": {
+              "version": "1.11.0",
+              "bundled": true,
+              "requires": {
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
+              },
+              "dependencies": {
+                "esprima": {
+                  "version": "3.1.3",
+                  "bundled": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "events": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "events-light": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "chai": "^3.5.0"
+              }
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "he": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "htmljs-parser": {
+              "version": "2.5.0",
+              "bundled": true,
+              "requires": {
+                "char-props": "^0.1.5",
+                "complain": "^1.0.0"
+              }
+            },
+            "lasso-caching-fs": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "raptor-async": "^1.1.2"
+              }
+            },
+            "lasso-modules-client": {
+              "version": "2.0.5",
+              "bundled": true,
+              "requires": {
+                "lasso-package-root": "^1.0.0",
+                "raptor-polyfill": "^1.0.2"
+              }
+            },
+            "lasso-package-root": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "lasso-caching-fs": "^1.0.0"
+              }
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+              }
+            },
+            "listener-tracker": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+              }
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "property-handlers": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "q": {
+              "version": "1.5.1",
+              "bundled": true
+            },
+            "raptor-async": {
+              "version": "1.1.3",
+              "bundled": true
+            },
+            "raptor-json": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "raptor-strings": "^1.0.0"
+              }
+            },
+            "raptor-polyfill": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "raptor-promises": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "q": "^1.0.1",
+                "raptor-util": "^1.0.0"
+              },
+              "dependencies": {
+                "raptor-util": {
+                  "version": "1.1.2",
+                  "bundled": true
+                }
+              }
+            },
+            "raptor-regexp": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "raptor-strings": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "raptor-polyfill": "^1.0.1"
+              }
+            },
+            "raptor-util": {
+              "version": "3.2.0",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "rusha": {
+              "version": "0.8.13",
+              "bundled": true
+            },
+            "shorthash": {
+              "version": "0.0.2",
+              "bundled": true
+            },
+            "simple-sha1": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "rusha": "^0.8.1"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            },
+            "stackframe": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "try-require": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "~1.1.2"
+              }
+            },
+            "type-detect": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "warp10": {
+              "version": "1.3.6",
+              "bundled": true
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "prettier": {
+          "version": "1.15.3",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "raptor-async": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "redent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "sigmund": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        }
+      }
+    },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
+    "argly": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/argly/-/argly-1.2.0.tgz",
+      "integrity": "sha1-KydORVGin/XnGZ0u2XiOtm7TbmA="
+    },
+    "ast-types": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.6.tgz",
+      "integrity": "sha512-nHiuV14upVGl7MWwFUYbzJ6YlfwWS084CU9EA8HajfYQjMSli5TQi3UTRygGF58LFWVkXxS1rbgRhROEqlQkXg=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "debug": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "enquirer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.2.0.tgz",
+      "integrity": "sha512-etPgLOWzaJ7qgJyQEVvSG+vOjkldCYJ3ZnDsY/ZF++O/K30rbWUTyUdoz03fg1EF7WtJHIKWdQDHSSYtzNqtTQ==",
+      "requires": {
+        "ansi-colors": "^3.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg=="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
+    "json5": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
+    "lasso-caching-fs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lasso-caching-fs/-/lasso-caching-fs-1.0.2.tgz",
+      "integrity": "sha1-m+TrHwaqwSYDRMrq70LC8AhusQ0=",
+      "requires": {
+        "raptor-async": "^1.1.2"
+      }
+    },
+    "lasso-package-root": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lasso-package-root/-/lasso-package-root-1.0.1.tgz",
+      "integrity": "sha1-mX0OcfQdA8Xw+gmlvCmNeW+LLCM=",
+      "requires": {
+        "lasso-caching-fs": "^1.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
+    "raptor-async": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/raptor-async/-/raptor-async-1.1.3.tgz",
+      "integrity": "sha1-uDw8m2A9yYXCw6n3jStAc+b2Akw="
+    },
+    "recast": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.16.1.tgz",
+      "integrity": "sha512-ZUQm94F3AHozRaTo4Vz6yIgkSEZIL7p+BsWeGZ23rx+ZVRoqX+bvBA8br0xmCOU0DSR4qYGtV7Y5HxTsC4V78A==",
+      "requires": {
+        "ast-types": "0.11.6",
+        "esprima": "~4.0.0",
+        "private": "~0.1.5",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+    },
+    "resolve": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -8,6 +8,7 @@
     "@marko/migrate-v3-widget": "^1.0.5",
     "@marko/prettyprint": "^1.2.0",
     "argly": "^1.2.0",
+    "dependent-path-update": "^0.1.0",
     "enquirer": "^2.1.1",
     "glob": "^7.1.3",
     "lasso-package-root": "^1.0.1",

--- a/packages/migrate/src/index.js
+++ b/packages/migrate/src/index.js
@@ -51,7 +51,8 @@ export default async function(options = {}) {
   }
 
   const files = await getFiles(filePatterns, globOptions);
-  const migratedFiles = {};
+  const updatedFiles = {};
+  const movedFiles = {};
 
   await Promise.all(
     files.map(async file => {
@@ -64,7 +65,7 @@ export default async function(options = {}) {
         const ast = markoCompiler.parse(source, file, {
           onContext(ctx) {
             ctx.addMigration = add;
-            addDefaultMigrations(ctx, migratedFiles);
+            addDefaultMigrations(ctx, updatedFiles, movedFiles);
           },
           migrate: true,
           raw: true
@@ -72,7 +73,7 @@ export default async function(options = {}) {
 
         await runAutoMigrations(migrateHelper);
 
-        migratedFiles[file] = markoPrettyprint.prettyPrintAST(ast, {
+        updatedFiles[file] = markoPrettyprint.prettyPrintAST(ast, {
           syntax: options.syntax,
           maxLen: options.maxLen,
           noSemi: options.noSemi,
@@ -83,7 +84,10 @@ export default async function(options = {}) {
     })
   );
 
-  return migratedFiles;
+  return {
+    moved: movedFiles,
+    updated: updatedFiles
+  };
 }
 
 function getPackageRoot(dir) {

--- a/packages/migrate/src/util/default-migrations/component-file.js
+++ b/packages/migrate/src/util/default-migrations/component-file.js
@@ -1,11 +1,11 @@
 import migrateWidget from "@marko/migrate-v3-widget";
 
-export default function addComponentMigration(ctx, migratedFiles) {
+export default function addComponentMigration(ctx, updatedFiles) {
   ctx.addMigration({
     name: "componentFile",
     description: "Migrating widget file with defineComponent",
     async apply(helper, { filename }) {
-      migratedFiles[filename] = await migrateWidget(filename, {
+      updatedFiles[filename] = await migrateWidget(filename, {
         onContext(hub) {
           hub.addMigration = ctx.addMigration;
         }

--- a/packages/migrate/src/util/default-migrations/index.js
+++ b/packages/migrate/src/util/default-migrations/index.js
@@ -1,6 +1,6 @@
 import renameFile from "./rename-file";
 import componentFile from "./component-file";
-export default function addFileMigrations(ctx, migratedFiles) {
-  renameFile(ctx, migratedFiles);
+export default function addFileMigrations(ctx, migratedFiles, renamedFiles) {
+  renameFile(ctx, migratedFiles, renamedFiles);
   componentFile(ctx, migratedFiles);
 }

--- a/packages/migrate/src/util/default-migrations/rename-file.js
+++ b/packages/migrate/src/util/default-migrations/rename-file.js
@@ -1,16 +1,8 @@
-export default function addComponentMigration(ctx, migratedFiles) {
+export default function addComponentMigration(ctx, _, movedFiles) {
   ctx.addMigration({
     name: "renameFile",
-    async apply(helper, { from, to }) {
-      Object.defineProperty(migratedFiles, from, {
-        enumerable: true,
-        get() {
-          return null;
-        },
-        set(source) {
-          migratedFiles[to] = source;
-        }
-      });
+    async apply(_, { from, to }) {
+      movedFiles[from] = to;
     }
   });
 }

--- a/packages/migrate/test/fixtures/single-template-rename/snapshot-expected.marko
+++ b/packages/migrate/test/fixtures/single-template-rename/snapshot-expected.marko
@@ -1,8 +1,3 @@
-<!-- packages/migrate/test/fixtures/single-template-rename/index.marko -->
+<!-- packages/migrate/test/fixtures/single-template-rename/template.marko => packages/migrate/test/fixtures/single-template-rename/index.marko -->
 
 <div/>
-
-
-<!-- packages/migrate/test/fixtures/single-template-rename/template.marko -->
-
-removed

--- a/packages/migrate/test/index.test.js
+++ b/packages/migrate/test/index.test.js
@@ -7,20 +7,20 @@ const CWD = process.cwd();
 describe("scope(migrate)", () => {
   autotest("fixtures", async ({ dir, test, snapshot }) => {
     test(async () => {
-      const outputs = await migrate({
+      const { updated, moved } = await migrate({
         prompt() {},
         ignore: ["**/snapshot-*.*"],
         files: [`${dir}/**/*.marko`]
       });
 
       snapshot(
-        Object.entries(outputs)
+        Object.entries(updated)
           .sort(([a], [b]) => a.localeCompare(b))
           .map(
             ([file, source]) =>
-              `<!-- ${path.relative(CWD, file)} -->\n\n${
-                source == null ? "removed" : source
-              }`
+              `<!-- ${path.relative(CWD, file)}${
+                moved[file] ? ` => ${path.relative(CWD, moved[file])}` : ""
+              } -->\n\n${source}`
           )
           .join("\n\n"),
         {


### PR DESCRIPTION
## Description

This change adds leverages [dependent-path-update]() to automatically update paths in dependent files while renaming during migration.

This also includes a breaking change where the programatic API now exposes an `updated` property for migrated files and a `moved` property for moved files. This was done because these need to happen at different stages in the CI as a migrated file could also need to be updated if one of it's dependencies also moved.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
