### PR TITLE
Shorten end tag of dynamic tags

### DIFF
--- a/packages/prettyprint/src/printHtmlElement.js
+++ b/packages/prettyprint/src/printHtmlElement.js
@@ -104,6 +104,9 @@ module.exports = function printHtmlElement(node, printContext, writer) {
   var tagNameString = tagNameExpression
     ? `\${${formatJS(tagNameExpression, printContext, undefined, true)}}`
     : node.tagName;
+  var closeTagNameString = tagNameExpression
+    ? "</>"
+    : "</" + node.tagName + ">";
 
   writer.write(tagNameString);
 
@@ -263,7 +266,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
     return;
   }
 
-  var endTag = printContext.isHtmlSyntax ? "</" + tagNameString + ">" : "";
+  var endTag = printContext.isHtmlSyntax ? closeTagNameString : "";
 
   if (bodyText && !hasLineBreaks(bodyText)) {
     let endCol = writer.col + bodyText.length + endTag.length;
@@ -272,7 +275,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
       if (printContext.isConciseSyntax) {
         writer.write(" -- " + bodyText);
       } else {
-        writer.write(bodyText + "</" + tagNameString + ">");
+        writer.write(bodyText + closeTagNameString);
       }
       return;
     }

--- a/packages/prettyprint/src/printHtmlElement.js
+++ b/packages/prettyprint/src/printHtmlElement.js
@@ -104,9 +104,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
   var tagNameString = tagNameExpression
     ? `\${${formatJS(tagNameExpression, printContext, undefined, true)}}`
     : node.tagName;
-  var closingTagNameString = tagNameExpression
-    ? "</>"
-    : "</" + node.tagName + ">";
+  var endTagString = tagNameExpression ? "</>" : "</" + node.tagName + ">";
 
   writer.write(tagNameString);
 
@@ -266,7 +264,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
     return;
   }
 
-  var endTag = printContext.isHtmlSyntax ? closingTagNameString : "";
+  var endTag = printContext.isHtmlSyntax ? endTagString : "";
 
   if (bodyText && !hasLineBreaks(bodyText)) {
     let endCol = writer.col + bodyText.length + endTag.length;
@@ -275,7 +273,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
       if (printContext.isConciseSyntax) {
         writer.write(" -- " + bodyText);
       } else {
-        writer.write(bodyText + closingTagNameString);
+        writer.write(bodyText + endTagString);
       }
       return;
     }

--- a/packages/prettyprint/src/printHtmlElement.js
+++ b/packages/prettyprint/src/printHtmlElement.js
@@ -104,7 +104,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
   var tagNameString = tagNameExpression
     ? `\${${formatJS(tagNameExpression, printContext, undefined, true)}}`
     : node.tagName;
-  var closeTagNameString = tagNameExpression
+  var closingTagNameString = tagNameExpression
     ? "</>"
     : "</" + node.tagName + ">";
 
@@ -266,7 +266,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
     return;
   }
 
-  var endTag = printContext.isHtmlSyntax ? closeTagNameString : "";
+  var endTag = printContext.isHtmlSyntax ? closingTagNameString : "";
 
   if (bodyText && !hasLineBreaks(bodyText)) {
     let endCol = writer.col + bodyText.length + endTag.length;
@@ -275,7 +275,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
       if (printContext.isConciseSyntax) {
         writer.write(" -- " + bodyText);
       } else {
-        writer.write(bodyText + closeTagNameString);
+        writer.write(bodyText + closingTagNameString);
       }
       return;
     }

--- a/packages/prettyprint/test/autotest/dynamic-tag-name/expected.marko
+++ b/packages/prettyprint/test/autotest/dynamic-tag-name/expected.marko
@@ -1,10 +1,10 @@
 <for(element in blah)>
     <${element.foo}>
         <include("foo")/>
-    </${element.foo}>
+    </>
 </for>
 ~~~~~~~
 for(element in blah)
     <${element.foo}>
         <include("foo")/>
-    </${element.foo}>
+    </>


### PR DESCRIPTION
## Description

Added logic to shorten the end tag of dynamic tags

## Screenshots (if appropriate):

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
