### PR TITLE
fix: Multi file migrations

### DIFF
--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -65,8 +65,24 @@ migrate({
     // By default the cli mode uses enquirer to prompt the user via cli.
     // The programtic api does not come with this by default and can be overwritten.
     return prompt(options);
+  },
+  onWriteFile(file, source) {
+    // A file has been modified, we can save it to disk.
+    // Note you can also return a promise.
+    fs.writeFileSync(file, source, "utf-8");
+  },
+  onRenameFile(from, to) {
+    // A file has been renamed, lets move it on the disk.
+    // Note you can also return a promise.
+    fs.renameSync(file, fileNames[file]);
+  },
+  onUpdateDependents(from, to) {
+    // This indicates that the dependents of the `from` file need to update
+    // Their paths to point to the `to` file.
+    // When running in CLI mode this will use https://github.com/marko-js/utils/tree/master/packages/dependent-path-update
   }
-}).then(({ fileContents, fileNames }) => {
+}).then(() => {
+  // Migration has completed.
   // Output contains an object with all of the migrated component sources.
   console.log("migrated all files");
 

--- a/packages/migrate/src/util/default-migrations/component-file.js
+++ b/packages/migrate/src/util/default-migrations/component-file.js
@@ -1,16 +1,19 @@
 import migrateWidget from "@marko/migrate-v3-widget";
 
-export default function addComponentMigration(ctx, { fileContents }) {
+export default function addComponentMigration(ctx, { onWriteFile }) {
   ctx.addMigration({
     name: "componentFile",
     description: "Migrating widget file with defineComponent",
     async apply(_, { componentFile, templateFile }) {
-      fileContents[componentFile] = await migrateWidget(componentFile, {
-        templateFile,
-        onContext(hub) {
-          hub.addMigration = ctx.addMigration;
-        }
-      });
+      await onWriteFile(
+        componentFile,
+        await migrateWidget(componentFile, {
+          templateFile,
+          onContext(hub) {
+            hub.addMigration = ctx.addMigration;
+          }
+        })
+      );
     }
   });
 }

--- a/packages/migrate/src/util/default-migrations/index.js
+++ b/packages/migrate/src/util/default-migrations/index.js
@@ -1,6 +1,6 @@
 import updatePaths from "./update-paths";
 import componentFile from "./component-file";
-export default function addFileMigrations(ctx, result) {
-  updatePaths(ctx, result);
-  componentFile(ctx, result);
+export default function addFileMigrations(ctx, handlers) {
+  updatePaths(ctx, handlers);
+  componentFile(ctx, handlers);
 }

--- a/packages/migrate/src/util/default-migrations/update-paths.js
+++ b/packages/migrate/src/util/default-migrations/update-paths.js
@@ -1,18 +1,18 @@
 export default function addComponentMigration(
   ctx,
-  { fileNames, dependentPaths }
+  { onRenameFile, onUpdateDependents }
 ) {
   ctx.addMigration({
     name: "updateFilePath",
-    apply(_, { from, to }) {
-      fileNames[from] = to;
+    async apply(_, { from, to }) {
+      await onRenameFile(from, to);
     }
   });
 
   ctx.addMigration({
     name: "updateDependentPaths",
-    apply(_, { from, to }) {
-      dependentPaths[from] = to;
+    async apply(_, { from, to }) {
+      await onUpdateDependents(from, to);
     }
   });
 }

--- a/packages/migrate/test/index.test.js
+++ b/packages/migrate/test/index.test.js
@@ -7,10 +7,23 @@ const CWD = process.cwd();
 describe("scope(migrate)", () => {
   autotest("fixtures", async ({ dir, test, snapshot }) => {
     test(async () => {
-      const { fileContents, fileNames, dependentPaths } = await migrate({
-        prompt() {},
+      const fileContents = {};
+      const fileNames = {};
+      const dependentPaths = {};
+
+      await migrate({
         ignore: ["**/snapshot-*.*"],
-        files: [`${dir}/**/*.marko`]
+        files: [`${dir}/**/*.marko`],
+        prompt() {},
+        onWriteFile(file, contents) {
+          fileContents[file] = contents;
+        },
+        onRenameFile(from, to) {
+          fileNames[from] = to;
+        },
+        onUpdateDependents(from, to) {
+          dependentPaths[from] = to;
+        }
       });
 
       snapshot(


### PR DESCRIPTION
BREAKING CHANGE: The migrate programtic API has been updated to allow performing IO operations while running

## Description

Currently when running `marko migrate` against multiple files where one migration would rename a file updated in a previous migration can cause an invalid output.

This change ensures each file is migrated (including renames and dependent updates) serially and exposes events from the programatic API to handle this.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
