### PR TITLE
feat(prettyprint): remove unneeded parens (attrs) & blocks (scriptlets)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -834,7 +834,7 @@
 			"dependencies": {
 				"chalk": {
 					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
 					"dev": true,
 					"requires": {
@@ -1025,7 +1025,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -1132,7 +1132,7 @@
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
 			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
 			"dev": true
 		},
@@ -1528,7 +1528,7 @@
 			"dependencies": {
 				"callsites": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
 					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
 					"dev": true
 				}
@@ -1545,7 +1545,7 @@
 		},
 		"callsites": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
 			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
 			"dev": true
 		},
@@ -1686,7 +1686,7 @@
 			"dependencies": {
 				"slice-ansi": {
 					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+					"resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
 					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
 					"dev": true
 				}
@@ -1867,7 +1867,7 @@
 		},
 		"conventional-changelog-angular": {
 			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+			"resolved": "http://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
 			"dev": true,
 			"requires": {
@@ -2140,7 +2140,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -2158,7 +2158,7 @@
 		},
 		"conventional-commits-parser": {
 			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+			"resolved": "http://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
 			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
 			"dev": true,
 			"requires": {
@@ -2190,7 +2190,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -2291,7 +2291,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -2669,7 +2669,7 @@
 		},
 		"duplexer": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
 		},
@@ -3302,7 +3302,7 @@
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 					"dev": true,
 					"requires": {
@@ -3337,7 +3337,7 @@
 				},
 				"load-json-file": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
@@ -3356,7 +3356,7 @@
 				},
 				"meow": {
 					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+					"resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 					"dev": true,
 					"requires": {
@@ -3374,7 +3374,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
@@ -3409,7 +3409,7 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				},
@@ -3508,7 +3508,7 @@
 		},
 		"git-raw-commits": {
 			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+			"resolved": "http://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
 			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
 			"dev": true,
 			"requires": {
@@ -3538,7 +3538,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -3556,7 +3556,7 @@
 			"dependencies": {
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
@@ -3591,7 +3591,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -4186,7 +4186,7 @@
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
@@ -4308,7 +4308,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
 		},
@@ -4479,7 +4479,7 @@
 		},
 		"jest-get-type": {
 			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+			"resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
 			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
 			"dev": true
 		},
@@ -4570,7 +4570,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -4922,7 +4922,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -5256,7 +5256,7 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
 		},
@@ -5313,7 +5313,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"dev": true,
 			"requires": {
@@ -5341,7 +5341,7 @@
 			"dependencies": {
 				"commander": {
 					"version": "2.15.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
 					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
 					"dev": true
 				},
@@ -6857,7 +6857,7 @@
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true,
 			"optional": true
@@ -6901,7 +6901,7 @@
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 					"dev": true
 				}
@@ -6909,7 +6909,7 @@
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
@@ -7036,7 +7036,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
@@ -7256,7 +7256,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -7294,7 +7294,7 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
@@ -7425,7 +7425,7 @@
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
 					"dev": true
 				}
@@ -7506,7 +7506,7 @@
 		},
 		"require-uncached": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
@@ -7641,7 +7641,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
@@ -7994,7 +7994,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
@@ -8061,7 +8061,7 @@
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
@@ -8096,7 +8096,7 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
@@ -8261,7 +8261,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
@@ -8669,7 +8669,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {

--- a/packages/prettyprint/package-lock.json
+++ b/packages/prettyprint/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"marko": {
-			"version": "4.14.20",
-			"resolved": "https://registry.npmjs.org/marko/-/marko-4.14.20.tgz",
-			"integrity": "sha512-YZo+pLR2n9KJtgXTEgRFfPmGpWKzb0InL5OS9IWkPYVP2b/uw+qKuN3RURit56w8dfhR2jjk1XX7C4luXjwMRg==",
+			"version": "4.14.21",
+			"resolved": "https://registry.npmjs.org/marko/-/marko-4.14.21.tgz",
+			"integrity": "sha512-e4jfR/4P3NuoQIZsHuOh3VpIzagsYZKMiQM0gtRwRhmAqUgjVxJP5zEJUIl4KZv9xKjauWxy5ndListzuYsf6w==",
 			"requires": {
 				"app-module-path": "^2.2.0",
 				"argly": "^1.0.0",
@@ -20,7 +20,7 @@
 				"events": "^1.0.2",
 				"events-light": "^1.0.0",
 				"he": "^1.1.0",
-				"htmljs-parser": "^2.6.0",
+				"htmljs-parser": "^2.6.1",
 				"lasso-caching-fs": "^1.0.1",
 				"lasso-modules-client": "^2.0.4",
 				"lasso-package-root": "^1.0.1",
@@ -211,9 +211,9 @@
 					"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
 				},
 				"htmljs-parser": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.6.0.tgz",
-					"integrity": "sha512-T+kp/Ja6nQEMBBmy45DHJ30D1vSJwebwgsSQcQnEQSIybk7tEjJgMzr6/G3ZZXezFGJo8ogNgacLB03hA4Jtog==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.6.1.tgz",
+					"integrity": "sha512-YC3sIZq9BowjxHc1j66u8+t6BrOjXgP+m51Lo31lMRJ4G/hj2TY5e6qNf8MyD56ysdcwJM5PqzZuPuSIPwV4rg==",
 					"requires": {
 						"char-props": "^0.1.5",
 						"complain": "^1.0.0"

--- a/packages/prettyprint/package.json
+++ b/packages/prettyprint/package.json
@@ -8,7 +8,7 @@
     "argly": "^1.2.0",
     "editorconfig": "^0.15.2",
     "lasso-package-root": "^1.0.1",
-    "marko": "^4.14.20",
+    "marko": "^4.14.21",
     "minimatch": "^3.0.4",
     "prettier": "^1.15.3",
     "redent": "^2.0.0",

--- a/packages/prettyprint/src/printHtmlElement.js
+++ b/packages/prettyprint/src/printHtmlElement.js
@@ -160,7 +160,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
     if (attr.name) {
       attrStr += attr.name;
       if (attrValueStr) {
-        if (hasUnenclosedWhitespace(attr.value)) {
+        if (hasUnenclosedWhitespace(attrValueStr)) {
           attrStr += "=(" + attrValueStr + ")";
         } else {
           attrStr += "=" + attrValueStr;
@@ -169,7 +169,7 @@ module.exports = function printHtmlElement(node, printContext, writer) {
         attrStr += formatArgument(attr, printContext);
       }
     } else if (attr.spread) {
-      if (hasUnenclosedWhitespace(attr.value)) {
+      if (hasUnenclosedWhitespace(attrValueStr)) {
         attrStr += "...(" + attrValueStr + ")";
       } else {
         attrStr += "..." + attrValueStr;

--- a/packages/prettyprint/src/printScriptlet.js
+++ b/packages/prettyprint/src/printScriptlet.js
@@ -3,6 +3,7 @@
 const redent = require("redent");
 const toCode = require("./util/toCode");
 const formatJS = require("./util/formatJS");
+const hasUnenclosedNewlines = require("./util/hasUnenclosedNewlines");
 
 module.exports = function printScriptlet(node, printContext, writer) {
   const currentIndentString = printContext.currentIndentString;
@@ -16,13 +17,7 @@ module.exports = function printScriptlet(node, printContext, writer) {
   } else {
     const codeStr = toCode(code, printContext);
     const output = formatJS(codeStr, printContext);
-    const newLineCount = countNewLines(output);
-    const isInline =
-      newLineCount === 0 ||
-      (typeof code === "string" &&
-        !node.block &&
-        newLineCount === countNewLines(codeStr));
-
+    const isInline = !hasUnenclosedNewlines(output);
     if (isInline) {
       writer.write(`$ ${output}`);
     } else {
@@ -37,8 +32,3 @@ module.exports = function printScriptlet(node, printContext, writer) {
     }
   }
 };
-
-function countNewLines(str) {
-  const match = str.match(/[\r\n]/g);
-  return (match && match.length) || 0;
-}

--- a/packages/prettyprint/src/util/formatJS.js
+++ b/packages/prettyprint/src/util/formatJS.js
@@ -40,8 +40,8 @@ module.exports = function(code, printContext, expression) {
   }
 
   if (depth) {
-    code = redent(code, depth, indentString).trim();
+    code = redent(code, depth, indentString);
   }
 
-  return code;
+  return code.trim();
 };

--- a/packages/prettyprint/src/util/getUnenclosedAsString.js
+++ b/packages/prettyprint/src/util/getUnenclosedAsString.js
@@ -1,0 +1,92 @@
+const TOKENS = {};
+TOKENS["{"] = {
+  tokens: TOKENS,
+  end: "}"
+};
+TOKENS["["] = {
+  tokens: TOKENS,
+  end: "]"
+};
+TOKENS["("] = {
+  tokens: TOKENS,
+  end: ")"
+};
+TOKENS["/"] = {
+  noMatchPrevious: /[\]})A-Z0-9.]\s*$/i,
+  tokens: {
+    "[": {
+      tokens: {},
+      skipEscaped: true,
+      end: "]"
+    }
+  },
+  skipEscaped: true,
+  end: "/"
+};
+TOKENS['"'] = {
+  tokens: {},
+  skipEscaped: true,
+  end: '"'
+};
+TOKENS["'"] = {
+  tokens: {},
+  skipEscaped: true,
+  end: "'"
+};
+TOKENS["`"] = {
+  tokens: {
+    $: {
+      fullToken: "${",
+      tokens: TOKENS,
+      end: "}"
+    }
+  },
+  skipEscaped: true,
+  end: "`"
+};
+
+function getUnenclosedAsString(string) {
+  let stack = [];
+  let current = { tokens: TOKENS };
+  let unenclosed = "";
+  for (let index = 0; index < string.length; index++) {
+    const char = string[index];
+    let next;
+    if (current.skipEscaped && char === "\\") {
+      index++;
+      continue;
+    }
+    if ((next = current.tokens[char])) {
+      if (next.fullToken) {
+        if (
+          string.slice(index, index + next.fullToken.length) === next.fullToken
+        ) {
+          stack.push(current);
+          current = next;
+          index += next.fullToken.length - 1;
+          continue;
+        }
+      } else if (next.noMatchPrevious) {
+        if (!next.noMatchPrevious.test(string.slice(0, index))) {
+          stack.push(current);
+          current = next;
+          continue;
+        }
+      } else {
+        stack.push(current);
+        current = next;
+        continue;
+      }
+    }
+    if (current.end === char) {
+      current = stack.pop();
+      continue;
+    }
+    if (stack.length === 0) {
+      unenclosed += char;
+    }
+  }
+  return unenclosed;
+}
+
+module.exports = getUnenclosedAsString;

--- a/packages/prettyprint/src/util/hasUnenclosedNewlines.js
+++ b/packages/prettyprint/src/util/hasUnenclosedNewlines.js
@@ -1,0 +1,5 @@
+const getUnenclosedAsString = require("./getUnenclosedAsString");
+
+module.exports = function hasUnenclosedNewlines(codeString) {
+  return /\n|\r/.test(getUnenclosedAsString(codeString));
+};

--- a/packages/prettyprint/src/util/hasUnenclosedWhitespace.js
+++ b/packages/prettyprint/src/util/hasUnenclosedWhitespace.js
@@ -1,17 +1,5 @@
-const WHITE_SPACE_EXPRESSION_TYPES = [
-  "LogicalExpression",
-  "AssignmentExpression",
-  "ConditionalExpression",
-  "BinaryExpression",
-  "NewExpression",
-  "FunctionDeclaration",
-  "Assignment"
-];
+const getUnenclosedAsString = require("./getUnenclosedAsString");
 
-module.exports = function hasUnenclosedWhitespace(node) {
-  return (
-    node.value instanceof RegExp ||
-    (node.toString().indexOf(" ") !== -1 &&
-      WHITE_SPACE_EXPRESSION_TYPES.indexOf(node.type) !== -1)
-  );
+module.exports = function hasUnenclosedWhitespace(codeString) {
+  return /\s/.test(getUnenclosedAsString(codeString));
 };

--- a/packages/prettyprint/test/autotest/attr-regex-literal/expected.marko
+++ b/packages/prettyprint/test/autotest/attr-regex-literal/expected.marko
@@ -1,3 +1,3 @@
-<div data-foo=(/abc/) data-bar=(/a bc/)/>
+<div data-foo=/abc/ data-bar=/a bc//>
 ~~~~~~~
-div data-foo=(/abc/) data-bar=(/a bc/)
+div data-foo=/abc/ data-bar=/a bc/

--- a/packages/prettyprint/test/autotest/js-line-unformatted/expected.marko
+++ b/packages/prettyprint/test/autotest/js-line-unformatted/expected.marko
@@ -1,11 +1,7 @@
-$ {
-    console.log({
-        foo: "bar" + 1
-    });
-}
+$ console.log({
+    foo: "bar" + 1
+});
 ~~~~~~~
-$ {
-    console.log({
-        foo: "bar" + 1
-    });
-}
+$ console.log({
+    foo: "bar" + 1
+});


### PR DESCRIPTION
BREAKING CHANGE: RegExp are now parsed and unwrapped - requires `marko@>=4.14.21`

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
