### PR TITLE
fix(prettyprint): attribute with multiple lines

### DIFF
--- a/packages/prettyprint/package-lock.json
+++ b/packages/prettyprint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@marko/prettyprint",
-	"version": "1.4.1",
+	"version": "2.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/prettyprint/test/autotest/attr-with-newlines/expected.marko
+++ b/packages/prettyprint/test/autotest/attr-with-newlines/expected.marko
@@ -1,0 +1,64 @@
+<div class=(
+    [
+        "test-class",
+        input.mobile && input.thing !== false && "test-class-thing",
+        input.mobile && "test-class-mobile"
+    ]
+        .filter(className => className)
+        .join(" ")
+)/>
+<div data-current-text=(
+    current &&
+        current
+            .replace("{page_number}", "{item_number}")
+            .replace("{current_page}", "{item_number}")
+)/>
+<div
+    class=(
+        [
+            "test-class",
+            input.mobile && input.thing !== false && "test-class-thing",
+            input.mobile && "test-class-mobile"
+        ]
+            .filter(className => className)
+            .join(" ")
+    )
+    data-current-text=(
+        current &&
+            current
+                .replace("{page_number}", "{item_number}")
+                .replace("{current_page}", "{item_number}")
+    )/>
+~~~~~~~
+div class=(
+    [
+        "test-class",
+        input.mobile && input.thing !== false && "test-class-thing",
+        input.mobile && "test-class-mobile"
+    ]
+        .filter(className => className)
+        .join(" ")
+)
+div data-current-text=(
+    current &&
+        current
+            .replace("{page_number}", "{item_number}")
+            .replace("{current_page}", "{item_number}")
+)
+div [
+    class=(
+        [
+            "test-class",
+            input.mobile && input.thing !== false && "test-class-thing",
+            input.mobile && "test-class-mobile"
+        ]
+            .filter(className => className)
+            .join(" ")
+    )
+    data-current-text=(
+        current &&
+            current
+                .replace("{page_number}", "{item_number}")
+                .replace("{current_page}", "{item_number}")
+    )
+]

--- a/packages/prettyprint/test/autotest/attr-with-newlines/template.marko
+++ b/packages/prettyprint/test/autotest/attr-with-newlines/template.marko
@@ -1,0 +1,4 @@
+<div class= ["test-class", input.mobile && input.thing !== false && "test-class-thing", input.mobile && "test-class-mobile"].filter(className => className).join(" ")/>
+<div data-current-text=(current && current.replace("{page_number}", "{item_number}").replace("{current_page}", "{item_number}"))/>
+
+<div class= ["test-class", input.mobile && input.thing !== false && "test-class-thing", input.mobile && "test-class-mobile"].filter(className => className).join(" ") data-current-text=(current && current.replace("{page_number}", "{item_number}").replace("{current_page}", "{item_number}"))/>


### PR DESCRIPTION
## Description

Fixes indentation of attributes when the content of an attribute spans multiple lines.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
