### PR TITLE
fix(prettyprint): improve printing of nested attributes

### DIFF
--- a/packages/prettyprint/src/util/formatJS.js
+++ b/packages/prettyprint/src/util/formatJS.js
@@ -39,9 +39,5 @@ module.exports = function(code, printContext, expression) {
     }
   }
 
-  if (depth) {
-    code = redent(code, depth, indentString);
-  }
-
-  return code.trim();
+  return redent(code, depth, indentString).trim();
 };

--- a/packages/prettyprint/test/autotest/attr-new/expected.marko
+++ b/packages/prettyprint/test/autotest/attr-new/expected.marko
@@ -1,3 +1,3 @@
 <var date=(new Date(2000, 1, 1))/>
 ~~~~~~~
-var date=(new Date(2000, 1, 1));
+var date=(new Date(2000, 1, 1))

--- a/packages/prettyprint/test/autotest/attr-newline-nested/expected.marko
+++ b/packages/prettyprint/test/autotest/attr-newline-nested/expected.marko
@@ -1,0 +1,38 @@
+<div style={
+    "background-color": imageCreative.contentBackgroundColor
+}>
+    <div
+        class="test"
+        style={
+            "background-color": imageCreative.contentBackgroundColor
+        }>
+        <div
+            class="test"
+            style={
+                "background-color": imageCreative.contentBackgroundColor
+            }>
+            <div style={
+                "background-color": imageCreative.contentBackgroundColor
+            }/>
+        </div>
+    </div>
+</div>
+~~~~~~~
+div style={
+    "background-color": imageCreative.contentBackgroundColor
+}
+    div [
+        class="test"
+        style={
+            "background-color": imageCreative.contentBackgroundColor
+        }
+    ]
+        div [
+            class="test"
+            style={
+                "background-color": imageCreative.contentBackgroundColor
+            }
+        ]
+            div style={
+                "background-color": imageCreative.contentBackgroundColor
+            }

--- a/packages/prettyprint/test/autotest/attr-newline-nested/template.marko
+++ b/packages/prettyprint/test/autotest/attr-newline-nested/template.marko
@@ -1,0 +1,21 @@
+<div
+    style={
+                        "background-color": imageCreative.contentBackgroundColor
+                    }>
+<div
+    class="test"
+    style={
+                        "background-color": imageCreative.contentBackgroundColor
+                    }>
+<div
+    class="test"
+    style={
+                        "background-color": imageCreative.contentBackgroundColor
+                    }>
+<div
+    style={
+                        "background-color": imageCreative.contentBackgroundColor
+                    }/>
+</div>
+</div>
+</div>

--- a/packages/prettyprint/test/autotest/attr-object-literal/expected.marko
+++ b/packages/prettyprint/test/autotest/attr-object-literal/expected.marko
@@ -1,23 +1,28 @@
-<div data-foo={
-    a: 1,
-    b: 2
-} data-bar={
-    a: 1,
-    b: 2
-}>
+<div
+    data-foo={
+        a: 1,
+        b: 2
+    }
+    data-bar={
+        a: 1,
+        b: 2
+    }>
     <div data-indented={
         a: 1,
         b: 2
     }/>
 </div>
 ~~~~~~~
-div data-foo={
-    a: 1,
-    b: 2
-} data-bar={
-    a: 1,
-    b: 2
-}
+div [
+    data-foo={
+        a: 1,
+        b: 2
+    }
+    data-bar={
+        a: 1,
+        b: 2
+    }
+]
     div data-indented={
         a: 1,
         b: 2

--- a/packages/prettyprint/test/autotest/attrs-multiline-nested/expected.marko
+++ b/packages/prettyprint/test/autotest/attrs-multiline-nested/expected.marko
@@ -11,7 +11,9 @@
         data-hello="hello"
         data-world="world"
         class="my-class"
-        data-widget="my-really-awesome-weidget">Hello World</div>
+        data-widget="my-really-awesome-weidget">
+        Hello World
+    </div>
 </div>
 ~~~~~~~
 div [

--- a/packages/prettyprint/test/autotest/attrs-multiline/expected.marko
+++ b/packages/prettyprint/test/autotest/attrs-multiline/expected.marko
@@ -4,7 +4,9 @@
     data-hello="hello"
     data-world="world"
     class="my-class"
-    data-widget="my-really-awesome-weidget">Hello World</div>
+    data-widget="my-really-awesome-weidget">
+    Hello World
+</div>
 ~~~~~~~
 div [
     data-foo="foo"

--- a/packages/prettyprint/test/autotest/max-line-length/expected.marko
+++ b/packages/prettyprint/test/autotest/max-line-length/expected.marko
@@ -9,7 +9,9 @@
             class="super-duper-long__class-name"
             data-test="test attribute data"
             data-more="more attribute data"
-            style="display: inline;">Hello ${data.name}!</h2>
+            style="display: inline;">
+            Hello ${data.name}!
+        </h2>
     </body>
 </html>
 ~~~~~~~

--- a/packages/prettyprint/test/autotest/var-array/expected.marko
+++ b/packages/prettyprint/test/autotest/var-array/expected.marko
@@ -8,8 +8,10 @@
     </span>
 </app-button>
 ~~~~~~~
-var classNames=["app-checkbox", state.checked && "checked", state.checkboxClassName],
-    foo="bar";
+var [
+    classNames=["app-checkbox", state.checked && "checked", state.checkboxClassName]
+    foo="bar"
+]
 app-button ref="button" class=classNames onClick("handleClick")
     span class="app-checkbox-icon"
     span ref="checkboxLabel"

--- a/packages/prettyprint/test/autotest/var-concise/expected.marko
+++ b/packages/prettyprint/test/autotest/var-concise/expected.marko
@@ -1,3 +1,3 @@
 <var foo=123 bar="hello"/>
 ~~~~~~~
-var foo=123, bar="hello";
+var foo=123 bar="hello"


### PR DESCRIPTION
## Description

Currently attributes that span multiple lines break when nested. This PR cleans up attribute printing and fixes this issue.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
