### PR TITLE
feat(test): add renderAsync method to server context

### DIFF
--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -105,11 +105,12 @@ test("variant-info", function(context) {
   );
 });
 
-// Async test:
-test("my async test", function(context, done) {
-  setTimeout(function() {
-    done();
-  }, 100);
+// Async test: (will be required if using any tags that are async)
+test("my async test", async function(contex) {
+  var output = await context.renderAsync({ variant: "danger" });
+  expect(output.$("button").attr("class")).to.equal(
+    "app-button app-button-info"
+  );
 });
 
 // Use test.only to only run a single test:

--- a/packages/test/src/util/server-tests-runner/ServerContext.js
+++ b/packages/test/src/util/server-tests-runner/ServerContext.js
@@ -47,26 +47,50 @@ class ServerContext {
       htmlString = this.component.render(data).toString();
     }
 
-    var snapshotId = this._nextSnapshotId++;
-    let snapshotFile =
-      this.name.replace(/[^A-Za-z0-9_\-.]/g, "-") + "." + snapshotId + ".html";
-    let testDir = path.join(this.componentDir, "test");
-    let snapshotDir = path.join(this.componentDir, "test/snapshots");
-
-    // Snapshots should always be placed in /test/snapshots even if the test file is located
-    // at the component level
-    if (!fs.existsSync(testDir)) {
-      fs.mkdirSync(testDir);
-    }
-
-    if (!fs.existsSync(snapshotDir)) {
-      fs.mkdirSync(snapshotDir);
-    }
-
-    fs.writeFileSync(path.join(snapshotDir, snapshotFile), htmlString);
-
+    createSnapshot(
+      this.name,
+      this._nextSnapshotId++,
+      this.componentDir,
+      htmlString
+    );
     return new RenderResult(htmlString);
   }
+
+  renderAsync(data) {
+    return new Promise((resolve, reject) =>
+      this.component.render(data, (err, result) =>
+        err ? reject(err) : resolve(result)
+      )
+    ).then(result => {
+      var htmlString = String(result);
+      createSnapshot(
+        this.name,
+        this._nextSnapshotId++,
+        this.componentDir,
+        htmlString
+      );
+      return new RenderResult(htmlString);
+    });
+  }
+}
+
+function createSnapshot(name, id, componentDir, html) {
+  const snapshotFile =
+    name.replace(/[^A-Za-z0-9_\-.]/g, "-") + "." + id + ".html";
+  const testDir = path.join(componentDir, "test");
+  const snapshotDir = path.join(componentDir, "test/snapshots");
+
+  // Snapshots should always be placed in /test/snapshots even if the test file is located
+  // at the component level
+  if (!fs.existsSync(testDir)) {
+    fs.mkdirSync(testDir);
+  }
+
+  if (!fs.existsSync(snapshotDir)) {
+    fs.mkdirSync(snapshotDir);
+  }
+
+  fs.writeFileSync(path.join(snapshotDir, snapshotFile), html);
 }
 
 module.exports = ServerContext;


### PR DESCRIPTION
## Description

Adds a new `renderAsync` to the server side context allowing for async tests to run. (context.render was synchronous 👎).

fixes #15 

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
