### PR TITLE
fix(prettyprint): printing expressions with uneven parens

### DIFF
--- a/packages/prettyprint/src/util/formatJS.js
+++ b/packages/prettyprint/src/util/formatJS.js
@@ -13,16 +13,16 @@ module.exports = function(code, printContext, expression) {
   const isExpression = expression || /^class *?\{/.test(code);
   const usedSpace = depth * tabWidth;
   const config = {
+    parser: "babel",
     semi: !printContext.noSemi,
     printWidth: Math.max(0, printContext.maxLen - usedSpace),
     singleQuote: printContext.singleQuote,
     useTabs: indentString[0] === "\t",
-    tabWidth,
-    parser: "babylon"
+    tabWidth
   };
 
   if (isExpression) {
-    code = "(" + code + ");";
+    code = "_ = " + code;
   }
 
   code = format(code, config)
@@ -30,12 +30,10 @@ module.exports = function(code, printContext, expression) {
     .replace(/__%ESCAPE%__/g, "\\");
 
   if (isExpression) {
+    code = code.slice(4);
+
     if (code[code.length - 1] === ";") {
       code = code.slice(0, -1);
-    }
-
-    if (code[0] === "(" && code[code.length - 1] === ")") {
-      code = code.slice(1, -1);
     }
   }
 

--- a/packages/prettyprint/test/autotest/attr-arrow-function-expression/expected.marko
+++ b/packages/prettyprint/test/autotest/attr-arrow-function-expression/expected.marko
@@ -1,0 +1,21 @@
+<div data-foo=(() => a.b())/>
+<div data-foo=(() => {
+    a.b();
+    c.d();
+})/>
+<div data-foo=(a => b.c())/>
+<div data-foo=((a, b) => {
+    c.d();
+    e.f();
+})/>
+~~~~~~~
+div data-foo=(() => a.b())
+div data-foo=(() => {
+    a.b();
+    c.d();
+})
+div data-foo=(a => b.c())
+div data-foo=((a, b) => {
+    c.d();
+    e.f();
+})

--- a/packages/prettyprint/test/autotest/attr-arrow-function-expression/template.marko
+++ b/packages/prettyprint/test/autotest/attr-arrow-function-expression/template.marko
@@ -1,0 +1,4 @@
+<div data-foo=(() => a.b())/>
+<div data-foo=(() => { a.b(); c.d(); })/>
+<div data-foo=((a) => b.c())/>
+<div data-foo=((a, b) => { c.d(); e.f(); })/>

--- a/packages/prettyprint/test/autotest/attr-with-newlines/expected.marko
+++ b/packages/prettyprint/test/autotest/attr-with-newlines/expected.marko
@@ -9,9 +9,9 @@
 )/>
 <div data-current-text=(
     current &&
-        current
-            .replace("{page_number}", "{item_number}")
-            .replace("{current_page}", "{item_number}")
+    current
+        .replace("{page_number}", "{item_number}")
+        .replace("{current_page}", "{item_number}")
 )/>
 <div
     class=(
@@ -25,9 +25,9 @@
     )
     data-current-text=(
         current &&
-            current
-                .replace("{page_number}", "{item_number}")
-                .replace("{current_page}", "{item_number}")
+        current
+            .replace("{page_number}", "{item_number}")
+            .replace("{current_page}", "{item_number}")
     )/>
 ~~~~~~~
 div class=(
@@ -41,9 +41,9 @@ div class=(
 )
 div data-current-text=(
     current &&
-        current
-            .replace("{page_number}", "{item_number}")
-            .replace("{current_page}", "{item_number}")
+    current
+        .replace("{page_number}", "{item_number}")
+        .replace("{current_page}", "{item_number}")
 )
 div [
     class=(
@@ -57,8 +57,8 @@ div [
     )
     data-current-text=(
         current &&
-            current
-                .replace("{page_number}", "{item_number}")
-                .replace("{current_page}", "{item_number}")
+        current
+            .replace("{page_number}", "{item_number}")
+            .replace("{current_page}", "{item_number}")
     )
 ]


### PR DESCRIPTION
## Description

Currently we have some simple logic to remove unneeded parenthesis (added by prettier) around expression statements. This just checked if the first and last char were parens and then removed them.

This would cause false positive such as:

```js
() => a.b()
```

This PR fixes this issue by having prettier print the value as a variable declarator instead of an expression statement which means it does not need to wrap it in parenthesis and we can remove the check.

Note: This was not an issue with `(a) => b()` because prettier would output `a => b()` which does not create the false positive.

## Motivation and Context

Fixes https://github.com/marko-js/marko/issues/1268

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
