### PR TITLE
fix(prettyprint): update whitespace preservation

### DIFF
--- a/packages/prettyprint/package-lock.json
+++ b/packages/prettyprint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@marko/prettyprint",
-	"version": "2.0.0",
+	"version": "2.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/prettyprint/src/printNodes.js
+++ b/packages/prettyprint/src/printNodes.js
@@ -186,7 +186,8 @@ module.exports = function printNodes(nodes, printContext, inputWriter) {
   });
 
   if (printContext.isHtmlSyntax && printContext.preserveWhitespace !== true) {
-    writer.rtrim();
+    var completeRTrim = avoidLineBreaks && allSimple;
+    writer.rtrim(completeRTrim);
 
     writer.write(printContext.eol);
 

--- a/packages/prettyprint/src/printNodes.js
+++ b/packages/prettyprint/src/printNodes.js
@@ -154,7 +154,9 @@ module.exports = function printNodes(nodes, printContext, inputWriter) {
         writer.write(printContext.currentIndentString);
       }
 
-      writer.write(HTMLTrim(childOutput, child, prevChild));
+      writer.write(
+        HTMLTrim(childOutput, child, prevChild, printContext.isHtmlSyntax)
+      );
 
       if (avoidLineBreaks) {
         if (
@@ -235,7 +237,7 @@ module.exports = function printNodes(nodes, printContext, inputWriter) {
   }
 };
 
-function HTMLTrim(content, child, prevChild) {
+function HTMLTrim(content, child, prevChild, isHtmlSyntax) {
   var startWhitespace = /^\s*/.exec(content)[0];
   var endWhitespace = /\s*$/.exec(content)[0];
   content = content.slice(
@@ -252,6 +254,24 @@ function HTMLTrim(content, child, prevChild) {
       child.nextSibling.type === "Text"
     ) {
       content += " ";
+    }
+  }
+  if (isHtmlSyntax && child.type === "HtmlElement") {
+    //check if next node is Text with just whitespace as content
+    var nextNode = child.nextSibling;
+    if (
+      nextNode &&
+      nextNode.type === "Text" &&
+      nextNode.argument &&
+      nextNode.argument.value &&
+      nextNode.argument.value.trim() === ""
+    ) {
+      if (
+        !nextNode.argument.value.match(/^\n+/) &&
+        !nextNode.argument.value.match(/\n+$/)
+      ) {
+        content += " ";
+      }
     }
   }
   return content;

--- a/packages/prettyprint/src/printText.js
+++ b/packages/prettyprint/src/printText.js
@@ -27,8 +27,10 @@ module.exports = function printText(node, printContext, writer) {
 
   var lines = text.split(/\r\n|\n/);
 
-  lines = trimLinesStart(lines);
-  lines = trimLinesEnd(lines);
+  if (lines.length > 1) {
+    lines = trimLinesStart(lines);
+    lines = trimLinesEnd(lines);
+  }
 
   if (lines.length === 0) {
     return;
@@ -49,10 +51,20 @@ module.exports = function printText(node, printContext, writer) {
           "---"
       );
     } else {
-      let trimmed = lines[0].trim();
+      let trimmed = lines[0].trimLeft();
 
       if (trimmed.startsWith("<")) {
         writer.write(trimmed);
+      } else if (trimmed === "") {
+        writer.write(
+          "--" +
+            printContext.eol +
+            currentIndentString +
+            lines[0] +
+            printContext.eol +
+            currentIndentString +
+            "--"
+        );
       } else {
         writer.write("-- " + trimmed);
       }

--- a/packages/prettyprint/src/printText.js
+++ b/packages/prettyprint/src/printText.js
@@ -66,6 +66,7 @@ module.exports = function printText(node, printContext, writer) {
             "--"
         );
       } else {
+        if (lines[0].match(/^\s+/) != null) trimmed = " " + trimmed;
         writer.write("-- " + trimmed);
       }
     }

--- a/packages/prettyprint/src/util/Writer.js
+++ b/packages/prettyprint/src/util/Writer.js
@@ -18,8 +18,8 @@ class Writer {
     this.buffer += str;
   }
 
-  rtrim() {
-    var trimmed = trim.rtrim(this.buffer);
+  rtrim(completeRTrim = false) {
+    var trimmed = trim.rtrim(this.buffer, completeRTrim);
     this.buffer = "";
     this.write(trimmed);
   }

--- a/packages/prettyprint/src/util/trim.js
+++ b/packages/prettyprint/src/util/trim.js
@@ -1,7 +1,11 @@
 "use strict";
 
-exports.rtrim = function rtrim(s) {
-  return s && s.replace(/\s+$/, "");
+exports.rtrim = function rtrim(s, completeRTrim) {
+  if (completeRTrim) {
+    return s && s.replace(/\s+$/, "");
+  }
+  while (s && s.match(/\n[\s]+\n$/) != null) s = s.replace(/\n[\s]+\n$/, "");
+  return s && s.replace(/\n+$/, "");
 };
 
 exports.ltrim = function ltrim(s) {

--- a/packages/prettyprint/test/autotest/comments-inline/expected.marko
+++ b/packages/prettyprint/test/autotest/comments-inline/expected.marko
@@ -1,7 +1,7 @@
 -- Hello
 <!-- This is an inline comment -->
--- World
+--  World
 ~~~~~~~
 -- Hello
 // This is an inline comment
--- World
+--  World

--- a/packages/prettyprint/test/autotest/tag-whitespace/expected.marko
+++ b/packages/prettyprint/test/autotest/tag-whitespace/expected.marko
@@ -1,0 +1,55 @@
+<div>
+    ${text} 
+    <div/>
+</div>
+<div>
+    <div/> 
+    
+    <div/>
+</div>
+<div>
+    <span>
+        <span>A</span>
+    </span> 
+    
+    <span>
+        <span>B</span>
+    </span> 
+    
+    <span>
+        <span>C</span>
+    </span>
+</div>
+<div>${text}</div> 
+--
+ 
+--
+~~~~~~~
+div
+    ---
+    ${text} 
+    <div/>
+    ---
+div
+    div
+    --
+     
+    --
+    div
+div
+    span
+        span -- A
+    --
+     
+    --
+    span
+        span -- B
+    --
+     
+    --
+    span
+        span -- C
+div -- ${text}
+--
+ 
+--

--- a/packages/prettyprint/test/autotest/tag-whitespace/expected.marko
+++ b/packages/prettyprint/test/autotest/tag-whitespace/expected.marko
@@ -9,7 +9,7 @@
 </div>
 <div>
     <span>
-        <span>A</span>
+        <span>A</span> 
     </span> 
     
     <span>
@@ -39,6 +39,9 @@ div
 div
     span
         span -- A
+        --
+         
+        --
     --
      
     --

--- a/packages/prettyprint/test/autotest/tag-whitespace/template.marko
+++ b/packages/prettyprint/test/autotest/tag-whitespace/template.marko
@@ -1,0 +1,13 @@
+<div>
+  ${text} <div/>
+</div>
+
+<div>
+  <div/> <div/>
+</div>
+
+<div>
+  <span><span>A</span></span> <span><span>B</span></span> <span><span>C</span></span> 
+</div>
+
+<div> ${text}</div> 

--- a/packages/prettyprint/test/autotest/tag-whitespace/template.marko
+++ b/packages/prettyprint/test/autotest/tag-whitespace/template.marko
@@ -7,7 +7,7 @@
 </div>
 
 <div>
-  <span><span>A</span></span> <span><span>B</span></span> <span><span>C</span></span> 
+  <span><span>A</span> </span> <span><span>B</span></span> <span><span>C</span></span> 
 </div>
 
 <div> ${text}</div> 


### PR DESCRIPTION
## Description

This commit updates the prettyprint module. It ensures that the valid and required whitespace in original marko template are preserved while pretty printing.

## Motivation and Context

It was observed that when AST has Text node containing either only whitespaces or leading/trailing whitespace, it was being removed during pretty print. This caused the output template to render differently than the original template. This PR address this problem and ensures required whitespaces are preserved.

## Screenshots (if appropriate):

![Original template](https://user-images.githubusercontent.com/14868341/54788262-a5a59200-4beb-11e9-8756-ccdaac9bf3ce.png)

![Pretty printed Concise syntax of original template](https://user-images.githubusercontent.com/14868341/54788278-b2c28100-4beb-11e9-992a-37c9aa305fb7.png)


## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
