### PR TITLE
fix(prettyprint,migrate): cli aggregates errors and visually shows changed paths

### DIFF
--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -8,6 +8,7 @@
     "@marko/migrate-v3-widget": "^1.0.7",
     "@marko/prettyprint": "^2.0.4",
     "argly": "^1.2.0",
+    "chalk": "^2.4.2",
     "dependent-path-update": "^0.1.1",
     "enquirer": "^2.1.1",
     "glob": "^7.1.3",

--- a/packages/prettyprint/package-lock.json
+++ b/packages/prettyprint/package-lock.json
@@ -1,9 +1,120 @@
 {
 	"name": "@marko/prettyprint",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"argly": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/argly/-/argly-1.2.0.tgz",
+			"integrity": "sha1-KydORVGin/XnGZ0u2XiOtm7TbmA="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"commander": {
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"editorconfig": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+			"requires": {
+				"commander": "^2.19.0",
+				"lru-cache": "^4.1.5",
+				"semver": "^5.6.0",
+				"sigmund": "^1.0.1"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"indent-string": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+		},
+		"lasso-caching-fs": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/lasso-caching-fs/-/lasso-caching-fs-1.0.2.tgz",
+			"integrity": "sha1-m+TrHwaqwSYDRMrq70LC8AhusQ0=",
+			"requires": {
+				"raptor-async": "^1.1.2"
+			}
+		},
+		"lasso-package-root": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lasso-package-root/-/lasso-package-root-1.0.1.tgz",
+			"integrity": "sha1-mX0OcfQdA8Xw+gmlvCmNeW+LLCM=",
+			"requires": {
+				"lasso-caching-fs": "^1.0.0"
+			}
+		},
+		"lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"requires": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
 		"marko": {
 			"version": "4.14.21",
 			"resolved": "https://registry.npmjs.org/marko/-/marko-4.14.21.tgz",
@@ -422,10 +533,70 @@
 				}
 			}
 		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
 		"prettier": {
 			"version": "1.16.4",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
 			"integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g=="
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"raptor-async": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/raptor-async/-/raptor-async-1.1.3.tgz",
+			"integrity": "sha1-uDw8m2A9yYXCw6n3jStAc+b2Akw="
+		},
+		"redent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+			"requires": {
+				"indent-string": "^3.0.0",
+				"strip-indent": "^2.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+		},
+		"semver": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+		},
+		"sigmund": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+		},
+		"strip-indent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		}
 	}
 }

--- a/packages/prettyprint/package.json
+++ b/packages/prettyprint/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/marko-js/cli/issues/new?template=Bug_report.md",
   "dependencies": {
     "argly": "^1.2.0",
+    "chalk": "^2.4.2",
     "editorconfig": "^0.15.2",
     "lasso-package-root": "^1.0.1",
     "marko": "^4.14.21",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- only write files that have changed
  - `migrate` now runs `prettyprint` on the original source to use as a comparison
- don't bail on first error

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

### Unchanged files are greyed out & summary shows number of files updated
![image](https://user-images.githubusercontent.com/1958812/56315372-5f6d2100-610c-11e9-84e0-2be96859681a.png)

### The cli does not exit on first error. Files that error are printed in red.

![image](https://user-images.githubusercontent.com/1958812/56315096-b9211b80-610b-11e9-8034-290e70a3661c.png)

### Errors are aggregated and printed at the end.

![image](https://user-images.githubusercontent.com/1958812/56315026-942ca880-610b-11e9-8e82-317b0767f998.png)



## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
