### PR TITLE
fix: issue with adding a new route in serve

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -19,7 +19,6 @@
     "css-loader": "^3.5.3",
     "fast-glob": "^3.2.2",
     "file-loader": "^6.0.0",
-    "glob-to-regexp": "0.4.1",
     "ignore-loader": "0.1.2",
     "imagemin-webpack-plugin": "^2.4.2",
     "marko": "^4.21.7",

--- a/packages/build/src/index.js
+++ b/packages/build/src/index.js
@@ -164,6 +164,7 @@ module.exports = ({
   const serverConfig = {
     name: "Server",
     target: "async-node",
+    cache: false, // This is needed because `InjectPlugin` is caching, we need to make a PR to opt out of caching.
     entry: SERVER_FILE,
     output: {
       path: BUILD_PATH,

--- a/packages/serve/test/fixtures/add-route/after-serve-expected.html
+++ b/packages/serve/test/fixtures/add-route/after-serve-expected.html
@@ -1,0 +1,1 @@
+<body><h1>Index of <nav>/</nav></h1><main><a href="/a" title="a.marko"><img src="/assets/file.HASH.png"><span>a.marko</span></a><a href="/b" title="b.marko"><img src="/assets/file.HASH.png"><span>b.marko</span></a><span></span><span></span><span></span><span></span><span></span></main><footer>Icons by <a href="https://icons8.com">icons8</a></footer></body>

--- a/packages/serve/test/fixtures/add-route/build-expected.html
+++ b/packages/serve/test/fixtures/add-route/build-expected.html
@@ -1,0 +1,1 @@
+<body><h1>Index of <nav>/</nav></h1><main><a href="/a" title="a.marko"><img src="/assets/HASH.png"><span>a.marko</span></a><span></span><span></span><span></span><span></span><span></span></main><footer>Icons by <a href="https://icons8.com">icons8</a></footer></body>

--- a/packages/serve/test/fixtures/add-route/serve-expected.html
+++ b/packages/serve/test/fixtures/add-route/serve-expected.html
@@ -1,0 +1,1 @@
+<body><h1>Index of <nav>/</nav></h1><main><a href="/a" title="a.marko"><img src="/assets/file.HASH.png"><span>a.marko</span></a><span></span><span></span><span></span><span></span><span></span></main><footer>Icons by <a href="https://icons8.com">icons8</a></footer></body>

--- a/packages/serve/test/fixtures/add-route/target/a.marko
+++ b/packages/serve/test/fixtures/add-route/target/a.marko
@@ -1,0 +1,1 @@
+<h1>Hello Marko</h1>

--- a/packages/serve/test/fixtures/add-route/test.js
+++ b/packages/serve/test/fixtures/add-route/test.js
@@ -1,0 +1,11 @@
+import fs from "fs";
+import path from "path";
+
+export const test = async ({ page, screenshot, targetPath, isBuild }) => {
+  if (!isBuild) {
+    fs.writeFileSync(path.join(targetPath, "b.marko"), "<h1>UPDATED</h1>");
+    // page should automatically reload on change, let's wait
+    await new Promise(resolve => page.once("load", resolve));
+    await screenshot("after");
+  }
+};


### PR DESCRIPTION
# Description

Fixes a regression where new pages added when using `@marko/serve` do not cause a recompilation. 

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

