### PR TITLE
fix(build): remove bail option which was causing errors to be hidden

### DIFF
--- a/packages/build/src/index.js
+++ b/packages/build/src/index.js
@@ -141,7 +141,6 @@ module.exports = ({
 
   const sharedConfig = options => ({
     mode: MODE,
-    bail: true,
     context: __dirname,
     devtool: DEVTOOL,
     resolve: {


### PR DESCRIPTION
## Description

Removes `bail: true` from the webpack config in `@marko/build`. This option was causing `@marko/serve` to not display any errors to the user.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
