### PR TITLE
fix(build): asset cache header now set to 1 year

### DIFF
--- a/packages/build/src/files/server.js
+++ b/packages/build/src/files/server.js
@@ -12,7 +12,9 @@ if (process.env.NODE_ENV === "production") {
   gzipStatic = connectGzipStatic(
     // eslint-disable-next-line
     path.join(__non_webpack_require__.main.filename, "..", "assets"),
-    { maxAge: 31536000 }
+    {
+      maxAge: 60 * 60 * 24 * 365 * 1000 // 1 year in ms
+    }
   );
 }
 


### PR DESCRIPTION
## Description

Currently the `maxAge` option set was assumed to have been in seconds, like the `cache-control` header. However the `send` utility under the hood was expecting `ms`, and so we are actually not caching assets for long enough.

This PR fixes that by properly using `ms`.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
