### PR TITLE
fix(build): server bundle source maps in dev mode

### DIFF
--- a/packages/build/src/index.js
+++ b/packages/build/src/index.js
@@ -167,13 +167,16 @@ module.exports = ({
     ];
 
     serverPlugins = serverPlugins.concat(
-      new InjectPlugin(() => `import "source-map-support/register"`),
       getSharedCompressionPlugins(/^assets/)
     );
 
     clientPlugins = clientPlugins.concat(
       new MinifyCSSPlugin(),
       getSharedCompressionPlugins()
+    );
+  } else {
+    serverPlugins = serverPlugins.concat(
+      new InjectPlugin(() => `import "source-map-support/register"`)
     );
   }
 


### PR DESCRIPTION
## Description

The source map module was meant to be enabled in dev mode (prod should use `--enable-source-maps` flag with `node@12`. This PR fixes that module to be correctly loaded in dev mode.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
