### PR TITLE
feat: add support for custom webpack.config.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@babel/cli": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.4.tgz",
-			"integrity": "sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.10.5.tgz",
+			"integrity": "sha512-j9H9qSf3kLdM0Ao3aGPbGZ73mEA9XazuupcS6cDGWuiyAcANoguhP0r2Lx32H5JGw4sSSoHG3x/mxVnHgvOoyA==",
 			"dev": true,
 			"requires": {
 				"chokidar": "^2.1.8",
@@ -13,51 +13,51 @@
 				"convert-source-map": "^1.1.0",
 				"fs-readdir-recursive": "^1.1.0",
 				"glob": "^7.0.0",
-				"lodash": "^4.17.13",
+				"lodash": "^4.17.19",
 				"make-dir": "^2.1.0",
 				"slash": "^2.0.0",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.8.3"
+				"@babel/highlight": "^7.10.4"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.6.tgz",
-			"integrity": "sha512-5QPTrNen2bm7RBc7dsOmcA5hbrS4O2Vhmk5XOL4zWW/zD/hV0iinpefDlkm+tBBy8kDtFaaeEvmAqt+nURAV2g==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.5.tgz",
+			"integrity": "sha512-mPVoWNzIpYJHbWje0if7Ck36bpbtTvIxOi9+6WSK9wjGEXearAqlwBoTQvVjsAY2VIwgcs8V940geY3okzRCEw==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.11.1",
+				"browserslist": "^4.12.0",
 				"invariant": "^2.2.4",
 				"semver": "^5.5.0"
 			}
 		},
 		"@babel/core": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
-			"integrity": "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
+			"integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.6",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.6",
-				"@babel/parser": "^7.9.6",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.6",
-				"@babel/types": "^7.9.6",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.10.5",
+				"@babel/helper-module-transforms": "^7.10.5",
+				"@babel/helpers": "^7.10.4",
+				"@babel/parser": "^7.10.5",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.5",
+				"@babel/types": "^7.10.5",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
+				"lodash": "^4.17.19",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
@@ -81,371 +81,380 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
-			"integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+			"integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.9.6",
+				"@babel/types": "^7.10.5",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
-			"integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+			"integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
-			"integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+			"integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/helper-explode-assignable-expression": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.9.6.tgz",
-			"integrity": "sha512-x2Nvu0igO0ejXzx09B/1fGBxY9NXQlBW2kZsSxCJft+KHN8t9XWzIvFxtPHnBOAXpVsdxZKZFbRUC8TsNKajMw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
+			"integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.9.6",
-				"browserslist": "^4.11.1",
+				"@babel/compat-data": "^7.10.4",
+				"browserslist": "^4.12.0",
 				"invariant": "^2.2.4",
 				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.6.tgz",
-			"integrity": "sha512-6N9IeuyHvMBRyjNYOMJHrhwtu4WJMrYf8hVbEHD3pbbbmNOk1kmXSQs7bA4dYDUaIx4ZEzdnvo6NwC3WHd/Qow==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+			"integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.9.5",
-				"@babel/helper-member-expression-to-functions": "^7.8.3",
-				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.9.6",
-				"@babel/helper-split-export-declaration": "^7.8.3"
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-member-expression-to-functions": "^7.10.5",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.10.4"
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.8.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz",
-			"integrity": "sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
+			"integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.8.3",
-				"@babel/helper-regex": "^7.8.3",
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-regex": "^7.10.4",
 				"regexpu-core": "^4.7.0"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
-			"integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+			"integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.8.3",
-				"@babel/types": "^7.8.3",
-				"lodash": "^4.17.13"
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/types": "^7.10.5",
+				"lodash": "^4.17.19"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
-			"integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
+			"integrity": "sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.9.5"
+				"@babel/helper-get-function-arity": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
-			"integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+			"integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
-			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+			"integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.5"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
-			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
-			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+			"integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.6",
-				"@babel/helper-simple-access": "^7.8.3",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/template": "^7.8.6",
-				"@babel/types": "^7.9.0",
-				"lodash": "^4.17.13"
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.5",
+				"lodash": "^4.17.19"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
-			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
-			"integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+			"integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.13"
+				"lodash": "^4.17.19"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
-			"integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
+			"integrity": "sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.8.3",
-				"@babel/helper-wrap-function": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-wrap-function": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
-			"integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.8.3",
-				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/traverse": "^7.9.6",
-				"@babel/types": "^7.9.6"
+				"@babel/helper-member-expression-to-functions": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
-			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+			"integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3"
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
 			"dev": true
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
-			"integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
+			"integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.6.tgz",
-			"integrity": "sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.9.6",
-				"@babel/types": "^7.9.6"
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.9.0",
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
-			"integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+			"integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
-			"integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+			"integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-remap-async-to-generator": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.10.4",
 				"@babel/plugin-syntax-async-generators": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
-			"integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
+			"integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-create-class-features-plugin": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
-			"integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
+			"integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
-			"integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
+			"integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-json-strings": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-nullish-coalescing-operator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
-			"integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
+			"integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-numeric-separator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
-			"integrity": "sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.6.tgz",
-			"integrity": "sha512-Ga6/fhGqA9Hj+y6whNpPv8psyaK5xzrQwSPsGPloVkvmH+PqW1ixdnfJ9uIO06OjQNYol3PMnfmJ8vfZtkzF+A==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
+			"integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-				"@babel/plugin-transform-parameters": "^7.9.5"
+				"@babel/plugin-transform-parameters": "^7.10.4"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
-			"integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
+			"integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-chaining": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz",
-			"integrity": "sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.4.tgz",
+			"integrity": "sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
 			}
 		},
-		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.8.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.8.tgz",
-			"integrity": "sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==",
+		"@babel/plugin-proposal-private-methods": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
+			"integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.8.8",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-create-class-features-plugin": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
+			"integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -455,6 +464,15 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+			"integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-syntax-dynamic-import": {
@@ -485,12 +503,12 @@
 			}
 		},
 		"@babel/plugin-syntax-numeric-separator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz",
-			"integrity": "sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
@@ -521,394 +539,406 @@
 			}
 		},
 		"@babel/plugin-syntax-top-level-await": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
-			"integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
+			"integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
-			"integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
+			"integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
-			"integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
+			"integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-remap-async-to-generator": "^7.8.3"
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-remap-async-to-generator": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
-			"integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
+			"integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
-			"integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz",
+			"integrity": "sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"lodash": "^4.17.13"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.5.tgz",
-			"integrity": "sha512-x2kZoIuLC//O5iA7PEvecB105o7TLzZo8ofBVhP79N+DO3jaX+KYfww9TQcfBEZD0nikNyYcGB1IKtRq36rdmg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
+			"integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.8.3",
-				"@babel/helper-define-map": "^7.8.3",
-				"@babel/helper-function-name": "^7.9.5",
-				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.6",
-				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-define-map": "^7.10.4",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.10.4",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
-			"integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
+			"integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.9.5.tgz",
-			"integrity": "sha512-j3OEsGel8nHL/iusv/mRd5fYZ3DrOxWC82x0ogmdN/vHfAP4MYw+AFKYanzWlktNwikKvlzUV//afBW5FTp17Q==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
+			"integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
-			"integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
+			"integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-create-regexp-features-plugin": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
-			"integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
+			"integrity": "sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
-			"integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
+			"integrity": "sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.9.0.tgz",
-			"integrity": "sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
+			"integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
-			"integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
+			"integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
-			"integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
+			"integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-member-expression-literals": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
-			"integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
+			"integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.6.tgz",
-			"integrity": "sha512-zoT0kgC3EixAyIAU+9vfaUVKTv9IxBDSabgHoUCBP6FqEJ+iNiN7ip7NBKcYqbfUDfuC2mFCbM7vbu4qJgOnDw==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+			"integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-module-transforms": "^7.10.5",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.6.tgz",
-			"integrity": "sha512-7H25fSlLcn+iYimmsNe3uK1at79IE6SKW9q0/QeEHTMC9MdOZ+4bA+T1VFB5fgOqBWoqlifXRzYD0JPdmIrgSQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
+			"integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-simple-access": "^7.8.3",
+				"@babel/helper-module-transforms": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-simple-access": "^7.10.4",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.6.tgz",
-			"integrity": "sha512-NW5XQuW3N2tTHim8e1b7qGy7s0kZ2OH3m5octc49K1SdAKGxYxeIx7hiIz05kS1R2R+hOWcsr1eYwcGhrdHsrg==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
+			"integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.8.3",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-hoist-variables": "^7.10.4",
+				"@babel/helper-module-transforms": "^7.10.5",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz",
-			"integrity": "sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
+			"integrity": "sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-module-transforms": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
-			"integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
+			"integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.8.3"
+				"@babel/helper-create-regexp-features-plugin": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
-			"integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
+			"integrity": "sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
-			"integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
+			"integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz",
-			"integrity": "sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+			"integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-get-function-arity": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
-			"integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
+			"integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.8.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.7.tgz",
-			"integrity": "sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
+			"integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.14.2"
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
-			"integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
+			"integrity": "sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.6.tgz",
-			"integrity": "sha512-qcmiECD0mYOjOIt8YHNsAP1SxPooC/rDmfmiSK9BNY72EitdSc7l44WTEklaWuFtbOEBjNhWWyph/kOImbNJ4w==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.5.tgz",
+			"integrity": "sha512-tV4V/FjElJ9lQtyjr5xD2IFFbgY46r7EeVu5a8CpEKT5laheHKSlFeHjpkPppW3PqzGLAuv5k2qZX5LgVZIX5w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
 				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
-			"integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
+			"integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
-			"integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.4.tgz",
+			"integrity": "sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
-			"integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
+			"integrity": "sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-regex": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/helper-regex": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
-			"integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+			"integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-annotate-as-pure": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
-			"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
+			"integrity": "sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-transform-unicode-escapes": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
+			"integrity": "sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
-			"integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
+			"integrity": "sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3"
+				"@babel/helper-create-regexp-features-plugin": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.6.tgz",
-			"integrity": "sha512-0gQJ9RTzO0heXOhzftog+a/WyOuqMrAIugVYxMYf83gh1CQaQDjMtsOpqOwXyDL/5JcWsrCm8l4ju8QC97O7EQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.4.tgz",
+			"integrity": "sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.9.6",
-				"@babel/helper-compilation-targets": "^7.9.6",
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
-				"@babel/plugin-proposal-dynamic-import": "^7.8.3",
-				"@babel/plugin-proposal-json-strings": "^7.8.3",
-				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-proposal-numeric-separator": "^7.8.3",
-				"@babel/plugin-proposal-object-rest-spread": "^7.9.6",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-proposal-optional-chaining": "^7.9.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+				"@babel/compat-data": "^7.10.4",
+				"@babel/helper-compilation-targets": "^7.10.4",
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-plugin-utils": "^7.10.4",
+				"@babel/plugin-proposal-async-generator-functions": "^7.10.4",
+				"@babel/plugin-proposal-class-properties": "^7.10.4",
+				"@babel/plugin-proposal-dynamic-import": "^7.10.4",
+				"@babel/plugin-proposal-json-strings": "^7.10.4",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+				"@babel/plugin-proposal-numeric-separator": "^7.10.4",
+				"@babel/plugin-proposal-object-rest-spread": "^7.10.4",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
+				"@babel/plugin-proposal-optional-chaining": "^7.10.4",
+				"@babel/plugin-proposal-private-methods": "^7.10.4",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
 				"@babel/plugin-syntax-async-generators": "^7.8.0",
+				"@babel/plugin-syntax-class-properties": "^7.10.4",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
 				"@babel/plugin-syntax-json-strings": "^7.8.0",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-				"@babel/plugin-syntax-numeric-separator": "^7.8.0",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
-				"@babel/plugin-syntax-top-level-await": "^7.8.3",
-				"@babel/plugin-transform-arrow-functions": "^7.8.3",
-				"@babel/plugin-transform-async-to-generator": "^7.8.3",
-				"@babel/plugin-transform-block-scoped-functions": "^7.8.3",
-				"@babel/plugin-transform-block-scoping": "^7.8.3",
-				"@babel/plugin-transform-classes": "^7.9.5",
-				"@babel/plugin-transform-computed-properties": "^7.8.3",
-				"@babel/plugin-transform-destructuring": "^7.9.5",
-				"@babel/plugin-transform-dotall-regex": "^7.8.3",
-				"@babel/plugin-transform-duplicate-keys": "^7.8.3",
-				"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-				"@babel/plugin-transform-for-of": "^7.9.0",
-				"@babel/plugin-transform-function-name": "^7.8.3",
-				"@babel/plugin-transform-literals": "^7.8.3",
-				"@babel/plugin-transform-member-expression-literals": "^7.8.3",
-				"@babel/plugin-transform-modules-amd": "^7.9.6",
-				"@babel/plugin-transform-modules-commonjs": "^7.9.6",
-				"@babel/plugin-transform-modules-systemjs": "^7.9.6",
-				"@babel/plugin-transform-modules-umd": "^7.9.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
-				"@babel/plugin-transform-new-target": "^7.8.3",
-				"@babel/plugin-transform-object-super": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.9.5",
-				"@babel/plugin-transform-property-literals": "^7.8.3",
-				"@babel/plugin-transform-regenerator": "^7.8.7",
-				"@babel/plugin-transform-reserved-words": "^7.8.3",
-				"@babel/plugin-transform-shorthand-properties": "^7.8.3",
-				"@babel/plugin-transform-spread": "^7.8.3",
-				"@babel/plugin-transform-sticky-regex": "^7.8.3",
-				"@babel/plugin-transform-template-literals": "^7.8.3",
-				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
-				"@babel/plugin-transform-unicode-regex": "^7.8.3",
+				"@babel/plugin-syntax-top-level-await": "^7.10.4",
+				"@babel/plugin-transform-arrow-functions": "^7.10.4",
+				"@babel/plugin-transform-async-to-generator": "^7.10.4",
+				"@babel/plugin-transform-block-scoped-functions": "^7.10.4",
+				"@babel/plugin-transform-block-scoping": "^7.10.4",
+				"@babel/plugin-transform-classes": "^7.10.4",
+				"@babel/plugin-transform-computed-properties": "^7.10.4",
+				"@babel/plugin-transform-destructuring": "^7.10.4",
+				"@babel/plugin-transform-dotall-regex": "^7.10.4",
+				"@babel/plugin-transform-duplicate-keys": "^7.10.4",
+				"@babel/plugin-transform-exponentiation-operator": "^7.10.4",
+				"@babel/plugin-transform-for-of": "^7.10.4",
+				"@babel/plugin-transform-function-name": "^7.10.4",
+				"@babel/plugin-transform-literals": "^7.10.4",
+				"@babel/plugin-transform-member-expression-literals": "^7.10.4",
+				"@babel/plugin-transform-modules-amd": "^7.10.4",
+				"@babel/plugin-transform-modules-commonjs": "^7.10.4",
+				"@babel/plugin-transform-modules-systemjs": "^7.10.4",
+				"@babel/plugin-transform-modules-umd": "^7.10.4",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
+				"@babel/plugin-transform-new-target": "^7.10.4",
+				"@babel/plugin-transform-object-super": "^7.10.4",
+				"@babel/plugin-transform-parameters": "^7.10.4",
+				"@babel/plugin-transform-property-literals": "^7.10.4",
+				"@babel/plugin-transform-regenerator": "^7.10.4",
+				"@babel/plugin-transform-reserved-words": "^7.10.4",
+				"@babel/plugin-transform-shorthand-properties": "^7.10.4",
+				"@babel/plugin-transform-spread": "^7.10.4",
+				"@babel/plugin-transform-sticky-regex": "^7.10.4",
+				"@babel/plugin-transform-template-literals": "^7.10.4",
+				"@babel/plugin-transform-typeof-symbol": "^7.10.4",
+				"@babel/plugin-transform-unicode-escapes": "^7.10.4",
+				"@babel/plugin-transform-unicode-regex": "^7.10.4",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.9.6",
-				"browserslist": "^4.11.1",
+				"@babel/types": "^7.10.4",
+				"browserslist": "^4.12.0",
 				"core-js-compat": "^3.6.2",
 				"invariant": "^2.2.2",
 				"levenary": "^1.1.1",
@@ -929,53 +959,53 @@
 			}
 		},
 		"@babel/register": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.9.0.tgz",
-			"integrity": "sha512-Tv8Zyi2J2VRR8g7pC5gTeIN8Ihultbmk0ocyNz8H2nEZbmhp1N6q0A1UGsQbDvGP/sNinQKUHf3SqXwqjtFv4Q==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.10.5.tgz",
+			"integrity": "sha512-eYHdLv43nyvmPn9bfNfrcC4+iYNwdQ8Pxk1MFJuU/U5LpSYl/PH4dFMazCYZDFVi8ueG3shvO+AQfLrxpYulQw==",
 			"dev": true,
 			"requires": {
 				"find-cache-dir": "^2.0.0",
-				"lodash": "^4.17.13",
+				"lodash": "^4.17.19",
 				"make-dir": "^2.1.0",
 				"pirates": "^4.0.0",
 				"source-map-support": "^0.5.16"
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
-			"integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+			"integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/template": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/parser": "^7.8.6",
-				"@babel/types": "^7.8.6"
+				"@babel/code-frame": "^7.10.4",
+				"@babel/parser": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
-			"integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+			"integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.6",
-				"@babel/helper-function-name": "^7.9.5",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.9.6",
-				"@babel/types": "^7.9.6",
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.10.5",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.10.4",
+				"@babel/parser": "^7.10.5",
+				"@babel/types": "^7.10.5",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
+				"lodash": "^4.17.19"
 			},
 			"dependencies": {
 				"debug": {
@@ -996,13 +1026,13 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
-			"integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+			"integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.9.5",
-				"lodash": "^4.17.13",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -1240,6 +1270,51 @@
 			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				}
 			}
 		},
 		"@ebay/browserslist-config": {
@@ -1525,9 +1600,9 @@
 			}
 		},
 		"@lerna/conventional-commits": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.18.5.tgz",
-			"integrity": "sha512-qcvXIEJ3qSgalxXnQ7Yxp5H9Ta5TVyai6vEor6AAEHc20WiO7UIdbLDCxBtiiHMdGdpH85dTYlsoYUwsCJu3HQ==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.22.0.tgz",
+			"integrity": "sha512-z4ZZk1e8Mhz7+IS8NxHr64wyklHctCJyWpJKEZZPJiLFJ8yKto/x38O80R10pIzC0rr8Sy/OsjSH4bl0TbbgqA==",
 			"dev": true,
 			"requires": {
 				"@lerna/validation-error": "3.13.0",
@@ -1562,9 +1637,9 @@
 			}
 		},
 		"@lerna/create": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.21.0.tgz",
-			"integrity": "sha512-cRIopzKzE2vXJPmsiwCDMWo4Ct+KTmX3nvvkQLDoQNrrRK7w+3KQT3iiorbj1koD95RsVQA7mS2haWok9SIv0g==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.22.0.tgz",
+			"integrity": "sha512-MdiQQzCcB4E9fBF1TyMOaAEz9lUjIHp1Ju9H7f3lXze5JK6Fl5NYkouAvsLgY6YSIhXMY8AHW2zzXeBDY4yWkw==",
 			"dev": true,
 			"requires": {
 				"@evocateur/pacote": "^9.6.3",
@@ -1694,13 +1769,13 @@
 			}
 		},
 		"@lerna/github-client": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.16.5.tgz",
-			"integrity": "sha512-rHQdn8Dv/CJrO3VouOP66zAcJzrHsm+wFuZ4uGAai2At2NkgKH+tpNhQy2H1PSC0Ezj9LxvdaHYrUzULqVK5Hw==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.22.0.tgz",
+			"integrity": "sha512-O/GwPW+Gzr3Eb5bk+nTzTJ3uv+jh5jGho9BOqKlajXaOkMYGBELEAqV5+uARNGWZFvYAiF4PgqHb6aCUu7XdXg==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@octokit/plugin-enterprise-rest": "^3.6.1",
+				"@octokit/plugin-enterprise-rest": "^6.0.1",
 				"@octokit/rest": "^16.28.4",
 				"git-url-parse": "^11.1.2",
 				"npmlog": "^4.1.2"
@@ -1742,9 +1817,9 @@
 			}
 		},
 		"@lerna/import": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.21.0.tgz",
-			"integrity": "sha512-aISkL4XD0Dqf5asDaOZWu65jgj8fWUhuQseZWuQe3UfHxav69fTS2YLIngUfencaOSZVOcVCom28YCzp61YDxw==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.22.0.tgz",
+			"integrity": "sha512-uWOlexasM5XR6tXi4YehODtH9Y3OZrFht3mGUFFT3OIl2s+V85xIGFfqFGMTipMPAGb2oF1UBLL48kR43hRsOg==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
@@ -2088,9 +2163,9 @@
 			}
 		},
 		"@lerna/publish": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.21.0.tgz",
-			"integrity": "sha512-JZ+ehZB9UCQ9nqH8Ld/Yqc/If++aK/7XIubkrB9sQ5hf2GeIbmI/BrJpMgLW/e9T5bKrUBZPUvoUN3daVipA5A==",
+			"version": "3.22.1",
+			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.22.1.tgz",
+			"integrity": "sha512-PG9CM9HUYDreb1FbJwFg90TCBQooGjj+n/pb3gw/eH5mEDq0p8wKdLFe0qkiqUkm/Ub5C8DbVFertIo0Vd0zcw==",
 			"dev": true,
 			"requires": {
 				"@evocateur/libnpmaccess": "^3.1.2",
@@ -2114,7 +2189,7 @@
 				"@lerna/run-lifecycle": "3.16.2",
 				"@lerna/run-topologically": "3.18.5",
 				"@lerna/validation-error": "3.13.0",
-				"@lerna/version": "3.21.0",
+				"@lerna/version": "3.22.1",
 				"figgy-pudding": "^3.5.1",
 				"fs-extra": "^8.1.0",
 				"npm-package-arg": "^6.1.0",
@@ -2258,17 +2333,17 @@
 			}
 		},
 		"@lerna/version": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.21.0.tgz",
-			"integrity": "sha512-nIT3u43fCNj6uSMN1dRxFnF4GhmIiOEqSTkGSjrMU+8kHKwzOqS/6X6TOzklBmCyEZOpF/fLlGqH3BZHnwLDzQ==",
+			"version": "3.22.1",
+			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.22.1.tgz",
+			"integrity": "sha512-PSGt/K1hVqreAFoi3zjD0VEDupQ2WZVlVIwesrE5GbrL2BjXowjCsTDPqblahDUPy0hp6h7E2kG855yLTp62+g==",
 			"dev": true,
 			"requires": {
 				"@lerna/check-working-tree": "3.16.5",
 				"@lerna/child-process": "3.16.5",
 				"@lerna/collect-updates": "3.20.0",
 				"@lerna/command": "3.21.0",
-				"@lerna/conventional-commits": "3.18.5",
-				"@lerna/github-client": "3.16.5",
+				"@lerna/conventional-commits": "3.22.0",
+				"@lerna/github-client": "3.22.0",
 				"@lerna/gitlab-client": "3.15.0",
 				"@lerna/output": "3.13.0",
 				"@lerna/prerelease-id-from-version": "3.16.0",
@@ -2356,55 +2431,43 @@
 			"dev": true
 		},
 		"@octokit/auth-token": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
-			"integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+			"integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^2.0.0"
+				"@octokit/types": "^5.0.0"
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.1.tgz",
-			"integrity": "sha512-pOPHaSz57SFT/m3R5P8MUu4wLPszokn5pXcB/pzavLTQf2jbU+6iayTvzaY6/BiotuRS0qyEUkx3QglT4U958A==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.4.tgz",
+			"integrity": "sha512-ZJHIsvsClEE+6LaZXskDvWIqD3Ao7+2gc66pRG5Ov4MQtMvCU9wGu1TItw9aGNmRuU9x3Fei1yb+uqGaQnm0nw==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^2.11.1",
+				"@octokit/types": "^5.0.0",
 				"is-plain-object": "^3.0.0",
-				"universal-user-agent": "^5.0.0"
+				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
 				"is-plain-object": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-					"dev": true,
-					"requires": {
-						"isobject": "^4.0.0"
-					}
-				},
-				"isobject": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+					"integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
 					"dev": true
 				},
 				"universal-user-agent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-					"integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-					"dev": true,
-					"requires": {
-						"os-name": "^3.1.0"
-					}
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+					"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+					"dev": true
 				}
 			}
 		},
 		"@octokit/plugin-enterprise-rest": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-3.6.2.tgz",
-			"integrity": "sha512-3wF5eueS5OHQYuAEudkpN+xVeUsg8vYEMMenEzLphUZ7PRZ8OJtDcsreL3ad9zxXmBbaFWzLmFcdob5CLyZftA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-6.0.1.tgz",
+			"integrity": "sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw==",
 			"dev": true
 		},
 		"@octokit/plugin-paginate-rest": {
@@ -2414,6 +2477,17 @@
 			"dev": true,
 			"requires": {
 				"@octokit/types": "^2.0.1"
+			},
+			"dependencies": {
+				"@octokit/types": {
+					"version": "2.16.2",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+					"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+					"dev": true,
+					"requires": {
+						"@types/node": ">= 8"
+					}
+				}
 			}
 		},
 		"@octokit/plugin-request-log": {
@@ -2430,58 +2504,57 @@
 			"requires": {
 				"@octokit/types": "^2.0.1",
 				"deprecation": "^2.3.1"
+			},
+			"dependencies": {
+				"@octokit/types": {
+					"version": "2.16.2",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+					"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+					"dev": true,
+					"requires": {
+						"@types/node": ">= 8"
+					}
+				}
 			}
 		},
 		"@octokit/request": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.2.tgz",
-			"integrity": "sha512-zKdnGuQ2TQ2vFk9VU8awFT4+EYf92Z/v3OlzRaSh4RIP0H6cvW1BFPXq4XYvNez+TPQjqN+0uSkCYnMFFhcFrw==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.6.tgz",
+			"integrity": "sha512-9r8Sn4CvqFI9LDLHl9P17EZHwj3ehwQnTpTE+LEneb0VBBqSiI/VS4rWIBfBhDrDs/aIGEGZRSB0QWAck8u+2g==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.0.0",
-				"@octokit/types": "^2.11.1",
+				"@octokit/types": "^5.0.0",
 				"deprecation": "^2.0.0",
 				"is-plain-object": "^3.0.0",
 				"node-fetch": "^2.3.0",
 				"once": "^1.4.0",
-				"universal-user-agent": "^5.0.0"
+				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
 				"@octokit/request-error": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
-					"integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+					"integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
 					"dev": true,
 					"requires": {
-						"@octokit/types": "^2.0.0",
+						"@octokit/types": "^5.0.1",
 						"deprecation": "^2.0.0",
 						"once": "^1.4.0"
 					}
 				},
 				"is-plain-object": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-					"dev": true,
-					"requires": {
-						"isobject": "^4.0.0"
-					}
-				},
-				"isobject": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+					"integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
 					"dev": true
 				},
 				"universal-user-agent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-					"integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-					"dev": true,
-					"requires": {
-						"os-name": "^3.1.0"
-					}
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+					"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+					"dev": true
 				}
 			}
 		},
@@ -2494,12 +2567,23 @@
 				"@octokit/types": "^2.0.0",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
+			},
+			"dependencies": {
+				"@octokit/types": {
+					"version": "2.16.2",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+					"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+					"dev": true,
+					"requires": {
+						"@types/node": ">= 8"
+					}
+				}
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.43.1",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz",
-			"integrity": "sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==",
+			"version": "16.43.2",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
+			"integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
 			"dev": true,
 			"requires": {
 				"@octokit/auth-token": "^2.4.0",
@@ -2521,9 +2605,9 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "2.16.2",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
-			"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.1.0.tgz",
+			"integrity": "sha512-OFxUBgrEllAbdEmWp/wNmKIu5EuumKHG4sgy56vjZ8lXPgMhF05c76hmulfOdFHHYRpPj49ygOZJ8wgVsPecuA==",
 			"dev": true,
 			"requires": {
 				"@types/node": ">= 8"
@@ -2544,19 +2628,12 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-			"dev": true
-		},
 		"@types/glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
 			"requires": {
-				"@types/events": "*",
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
@@ -2574,9 +2651,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.0.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
-			"integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
+			"version": "14.0.23",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
+			"integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -2625,9 +2702,9 @@
 			"dev": true
 		},
 		"agent-base": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-			"integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+			"integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
 			"dev": true,
 			"requires": {
 				"debug": "4"
@@ -2660,9 +2737,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"version": "6.12.3",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+			"integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -2907,9 +2984,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
 			"dev": true
 		},
 		"babel-plugin-dynamic-import-node": {
@@ -3103,15 +3180,15 @@
 			"dev": true
 		},
 		"browserslist": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
-			"integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
+			"integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001043",
-				"electron-to-chromium": "^1.3.413",
-				"node-releases": "^1.1.53",
-				"pkg-up": "^2.0.0"
+				"caniuse-lite": "^1.0.30001093",
+				"electron-to-chromium": "^1.3.488",
+				"escalade": "^3.0.1",
+				"node-releases": "^1.1.58"
 			}
 		},
 		"btoa-lite": {
@@ -3258,9 +3335,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001061",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001061.tgz",
-			"integrity": "sha512-SMICCeiNvMZnyXpuoO+ot7FHpMVPlrsR+HmfByj6nY4xYDHXLqMTbgH7ecEkDNXWkH1vaip+ZS0D7VTXwM1KYQ==",
+			"version": "1.0.30001102",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001102.tgz",
+			"integrity": "sha512-fOjqRmHjRXv1H1YD6QVLb96iKqnu17TjcLSaX64TwhGYed0P1E1CCWZ9OujbbK4Z/7zax7zAzvQidzdtjx8RcA==",
 			"dev": true
 		},
 		"caseless": {
@@ -3483,6 +3560,18 @@
 				"js-yaml": "3.13.1",
 				"teeny-request": "6.0.1",
 				"urlgrey": "0.4.4"
+			},
+			"dependencies": {
+				"js-yaml": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				}
 			}
 		},
 		"collection-visit": {
@@ -3912,15 +4001,6 @@
 						}
 					}
 				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
 				"p-locate": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -3929,12 +4009,6 @@
 					"requires": {
 						"p-limit": "^2.2.0"
 					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
 				},
 				"parse-json": {
 					"version": "5.0.0",
@@ -3980,11 +4054,12 @@
 					}
 				},
 				"through2": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+					"integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
 					"dev": true,
 					"requires": {
+						"inherits": "^2.0.4",
 						"readable-stream": "2 || 3"
 					}
 				},
@@ -4146,15 +4221,6 @@
 						}
 					}
 				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
 				"p-locate": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -4163,12 +4229,6 @@
 					"requires": {
 						"p-limit": "^2.2.0"
 					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
 				},
 				"parse-json": {
 					"version": "5.0.0",
@@ -4259,11 +4319,12 @@
 					}
 				},
 				"through2": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+					"integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
 					"dev": true,
 					"requires": {
+						"inherits": "^2.0.4",
 						"readable-stream": "2 || 3"
 					}
 				},
@@ -4610,12 +4671,6 @@
 								"p-limit": "^1.1.0"
 							}
 						},
-						"p-try": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-							"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-							"dev": true
-						},
 						"path-exists": {
 							"version": "3.0.0",
 							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -4692,15 +4747,6 @@
 						}
 					}
 				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
 				"p-locate": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -4711,9 +4757,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 					"dev": true
 				},
 				"parse-json": {
@@ -4810,11 +4856,12 @@
 					}
 				},
 				"through2": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+					"integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
 					"dev": true,
 					"requires": {
+						"inherits": "^2.0.4",
 						"readable-stream": "2 || 3"
 					}
 				},
@@ -5289,9 +5336,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.441",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.441.tgz",
-			"integrity": "sha512-leBfJwLuyGs1jEei2QioI+PjVMavmUIvPYidE8dCCYWLAq0uefhN3NYgDNb8WxD3uiUNnJ3ScMXg0upSlwySzQ==",
+			"version": "1.3.499",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.499.tgz",
+			"integrity": "sha512-y7FwtQm/8xuLMnYQfBQDYzCpNn+VkSnf4c3Km5TWMNXg7JA5RQBuxmcLaKdDVcIK0K5xGIa7TlxpRt4BdNxNoA==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -5307,12 +5354,23 @@
 			"dev": true
 		},
 		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
 			"dev": true,
 			"requires": {
-				"iconv-lite": "~0.4.13"
+				"iconv-lite": "^0.6.2"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.6.2",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+					"integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+					"dev": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3.0.0"
+					}
+				}
 			}
 		},
 		"end-of-stream": {
@@ -5352,22 +5410,22 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-			"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+			"version": "1.17.6",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+			"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
+				"is-callable": "^1.2.0",
+				"is-regex": "^1.1.0",
 				"object-inspect": "^1.7.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
+				"string.prototype.trimend": "^1.0.1",
+				"string.prototype.trimstart": "^1.0.1"
 			}
 		},
 		"es-to-primitive": {
@@ -5401,6 +5459,12 @@
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
+		},
+		"escalade": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
+			"integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -5487,9 +5551,9 @@
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
-			"integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+			"integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
@@ -5515,9 +5579,9 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 			"dev": true
 		},
 		"espree": {
@@ -5753,9 +5817,9 @@
 			"dev": true
 		},
 		"fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
 		"fast-diff": {
@@ -5865,12 +5929,12 @@
 			}
 		},
 		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "^3.0.0"
 			}
 		},
 		"flat-cache": {
@@ -6819,48 +6883,23 @@
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
 				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
+						"p-locate": "^4.1.0"
 					}
 				},
 				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "^2.2.0"
 					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
 				},
 				"parse-json": {
 					"version": "5.0.0",
@@ -6873,6 +6912,12 @@
 						"json-parse-better-errors": "^1.0.1",
 						"lines-and-columns": "^1.1.6"
 					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
 				},
 				"pkg-dir": {
 					"version": "4.2.0",
@@ -6892,30 +6937,6 @@
 								"locate-path": "^5.0.0",
 								"path-exists": "^4.0.0"
 							}
-						},
-						"locate-path": {
-							"version": "5.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-							"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-							"dev": true,
-							"requires": {
-								"p-locate": "^4.1.0"
-							}
-						},
-						"p-locate": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-							"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-							"dev": true,
-							"requires": {
-								"p-limit": "^2.2.0"
-							}
-						},
-						"path-exists": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-							"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-							"dev": true
 						}
 					}
 				},
@@ -7158,9 +7179,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
 			"dev": true
 		},
 		"is-ci": {
@@ -7337,12 +7358,12 @@
 			"dev": true
 		},
 		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+			"integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-regexp": {
@@ -7556,9 +7577,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -7650,9 +7671,9 @@
 			"dev": true
 		},
 		"lerna": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.21.0.tgz",
-			"integrity": "sha512-ux8yOwQEgIXOZVUfq+T8nVzPymL19vlIoPbysOP3YA4hcjKlqQIlsjI/1ugBe6b4MF7W4iV5vS3gH9cGqBBc1A==",
+			"version": "3.22.1",
+			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.22.1.tgz",
+			"integrity": "sha512-vk1lfVRFm+UuEFA7wkLKeSF7Iz13W+N/vFd48aW2yuS7Kv0RbNm2/qcDPV863056LMfkRlsEe+QYOw3palj5Lg==",
 			"dev": true,
 			"requires": {
 				"@lerna/add": "3.21.0",
@@ -7660,17 +7681,17 @@
 				"@lerna/changed": "3.21.0",
 				"@lerna/clean": "3.21.0",
 				"@lerna/cli": "3.18.5",
-				"@lerna/create": "3.21.0",
+				"@lerna/create": "3.22.0",
 				"@lerna/diff": "3.21.0",
 				"@lerna/exec": "3.21.0",
-				"@lerna/import": "3.21.0",
+				"@lerna/import": "3.22.0",
 				"@lerna/info": "3.21.0",
 				"@lerna/init": "3.21.0",
 				"@lerna/link": "3.21.0",
 				"@lerna/list": "3.21.0",
-				"@lerna/publish": "3.21.0",
+				"@lerna/publish": "3.22.1",
 				"@lerna/run": "3.21.0",
-				"@lerna/version": "3.21.0",
+				"@lerna/version": "3.22.1",
 				"import-local": "^2.0.0",
 				"npmlog": "^4.1.2"
 			}
@@ -7906,19 +7927,19 @@
 			}
 		},
 		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
+				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
 			"dev": true
 		},
 		"lodash._reinterpolate": {
@@ -8049,9 +8070,9 @@
 			}
 		},
 		"macos-release": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.0.tgz",
+			"integrity": "sha512-ko6deozZYiAkqa/0gmcsz+p4jSy3gY7/ZsCEokPaYd8k+6/aXGkiTgr61+Owup7Sf+xjqW8u2ElhoM9SEcEfuA==",
 			"dev": true
 		},
 		"make-dir": {
@@ -8188,9 +8209,9 @@
 			}
 		},
 		"merge2": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true
 		},
 		"micromatch": {
@@ -8215,9 +8236,9 @@
 			}
 		},
 		"mime": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
-			"integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+			"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
 			"dev": true
 		},
 		"mime-db": {
@@ -8242,9 +8263,9 @@
 			"dev": true
 		},
 		"min-indent": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
-			"integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
 			"dev": true
 		},
 		"minimatch": {
@@ -8520,9 +8541,9 @@
 			"dev": true
 		},
 		"neo-async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
 		},
 		"nested-error-stacks": {
@@ -8555,9 +8576,9 @@
 			}
 		},
 		"node-gyp": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
-			"integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
+			"integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
 			"dev": true,
 			"requires": {
 				"env-paths": "^2.2.0",
@@ -8580,9 +8601,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.55",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.55.tgz",
-			"integrity": "sha512-H3R3YR/8TjT5WPin/wOoHOUPHgvj8leuU/Keta/rwelEQN9pA/S2Dx8/se4pZ2LBxSd0nAGzsNzhqwa77v7F1w==",
+			"version": "1.1.59",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
+			"integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw==",
 			"dev": true
 		},
 		"nopt": {
@@ -8793,49 +8814,6 @@
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -8936,9 +8914,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
 			"dev": true
 		},
 		"object-keys": {
@@ -9064,21 +9042,21 @@
 			"dev": true
 		},
 		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "^2.0.0"
 			}
 		},
 		"p-map": {
@@ -9118,9 +9096,9 @@
 			"dev": true
 		},
 		"p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
 		},
 		"p-waterfall": {
@@ -9310,60 +9288,6 @@
 			"dev": true,
 			"requires": {
 				"find-up": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				}
-			}
-		},
-		"pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-			"dev": true,
-			"requires": {
-				"find-up": "^2.1.0"
 			}
 		},
 		"please-upgrade-node": {
@@ -9401,12 +9325,6 @@
 			"requires": {
 				"fast-diff": "^1.1.2"
 			}
-		},
-		"private": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
@@ -9671,6 +9589,51 @@
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				}
 			}
 		},
 		"readable-stream": {
@@ -9723,9 +9686,9 @@
 			}
 		},
 		"regenerate": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
+			"integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
 			"dev": true
 		},
 		"regenerate-unicode-properties": {
@@ -9744,13 +9707,12 @@
 			"dev": true
 		},
 		"regenerator-transform": {
-			"version": "0.14.4",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
-			"integrity": "sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==",
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+			"integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.8.4",
-				"private": "^0.1.8"
+				"@babel/runtime": "^7.8.4"
 			}
 		},
 		"regex-not": {
@@ -9784,9 +9746,9 @@
 			}
 		},
 		"regjsgen": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
-			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+			"integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
 			"dev": true
 		},
 		"regjsparser": {
@@ -9992,9 +9954,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.5.5",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-			"integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
+			"integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -10352,9 +10314,9 @@
 			}
 		},
 		"spdx-correct": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -10520,28 +10482,6 @@
 				"es-abstract": "^1.17.5"
 			}
 		},
-		"string.prototype.trimleft": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-			"integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"string.prototype.trimstart": "^1.0.0"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-			"integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"string.prototype.trimend": "^1.0.0"
-			}
-		},
 		"string.prototype.trimstart": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
@@ -10638,9 +10578,9 @@
 			"dev": true
 		},
 		"synchronous-promise": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.12.tgz",
-			"integrity": "sha512-rIDJiHmIK02tXU+eW1v6a7rNIIiMLm5JUF5Uj2fT6oLSulg7WNDVoqvkYqkFoJzf4v2gmTLppvzegdo9R+7h1Q==",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.13.tgz",
+			"integrity": "sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA==",
 			"dev": true
 		},
 		"table": {
@@ -10760,49 +10700,6 @@
 				"require-main-filename": "^2.0.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
 				"read-pkg-up": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
@@ -10828,9 +10725,9 @@
 			"dev": true
 		},
 		"thenify": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-			"integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
 			"dev": true,
 			"requires": {
 				"any-promise": "^1.0.0"
@@ -10998,23 +10895,11 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.9.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
-			"integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
+			"integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
 			"dev": true,
-			"optional": true,
-			"requires": {
-				"commander": "~2.20.3"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true,
-					"optional": true
-				}
-			}
+			"optional": true
 		},
 		"uid-number": {
 			"version": "0.0.6",
@@ -11276,9 +11161,9 @@
 			}
 		},
 		"windows-release": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
-			"integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
+			"integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
 			"dev": true,
 			"requires": {
 				"execa": "^1.0.0"
@@ -11472,49 +11357,6 @@
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
 				"string-width": {

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -46,6 +46,44 @@ marko-build ./my-page.marko
 
 - `--output -o`: Where to write the build.
 
+# Config overrides
+
+While `@marko/build` works out-of-the box without any config, it does allow customizing and extending the default config for unique use-cases.
+
+## Webpack
+
+> **NOTE:** `@marko/build` currently uses webpack to build projects, however, this may change in the future so it's recommended to avoid using a custom webpack config if possible.
+
+In the most extreme case, you can use a custom `webpack.config.js`. This config file is discovered based on the entry that is passed to the cli command, but given that it's a standalone config file, you can use `webpack` directly to build your project as well.
+
+To help configure webpack, `@marko/build` exports a `configBuilder` function that allows you to use the base config, while adding your own customizations.
+
+### Example
+
+**webpack.config.js**
+
+```js
+import path from "path";
+import { configBuilder } from "@marko/build";
+import MyPlugin from "my-plugin";
+
+const { getServerConfig, getBrowserConfigs } = configBuilder({
+  entry: path.join(__dirname, "target.marko"),
+  production: process.env.NODE_ENV === "production"
+});
+
+module.exports = [
+  ...getBrowserConfigs(config => {
+    config.plugins.push(new MyPlugin());
+    return config;
+  }),
+  getServerConfig(config => {
+    config.plugins.push(new MyPlugin());
+    return config;
+  })
+];
+```
+
 # API
 
 ## Installation
@@ -54,24 +92,22 @@ marko-build ./my-page.marko
 npm install @marko/build
 ```
 
-## Example
+## `configBuilder`
 
-```javascript
-import build from "@marko/build";
+Returns 3 functions: `getServerConfig`, `getBrowserConfig`, and `getBrowserConfigs`.
 
-build({
-  file: "./component.marko"
-}).run(() => {
-  console.log("Build complete");
-});
-```
+### Options
 
-The object returned from the `build` function is a [webpack compiler instance](https://webpack.js.org/api/node/#compiler-instance).
-
-## Options
-
-- `file` - the marko file to build
+- `entry` - the marko file to build
 - `output` - where to write the build
-- `serverPlugins` - additional webpack plugins to run on the server build
-- `clientPlugins` - additional webpack plugins to run on the client build
+- `production` - whether to build in production mode
+
+## `loadWebpackConfig`
+
+Loads a custom `webpack.config.js` or creates a default array of compiler configs.
+
+### Options
+
+- `entry` - the marko file to build
+- `output` - where to write the build
 - `production` - whether to build in production mode

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"chalk": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-			"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -56,9 +56,9 @@
 			}
 		},
 		"marko": {
-			"version": "4.21.9",
-			"resolved": "https://registry.npmjs.org/marko/-/marko-4.21.9.tgz",
-			"integrity": "sha512-vFYrue+Hr1gDhU1Kh+pGkNPSm1qva/zzYtv5KFpgqZdflbGc7XUpkoBGnP+/lb6a/anfkPGqIOR7AuiQafgZ0w==",
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/marko/-/marko-4.22.0.tgz",
+			"integrity": "sha512-Cv404hwA0RZvRNGCSKC0rLvCNSj2AuLwO4ctkelzYFvkLq5BXonT6eeZEcMRsxOoMe5u4P3pQO3jmqlNJ8mtDA==",
 			"requires": {
 				"app-module-path": "^2.2.0",
 				"argly": "^1.0.0",
@@ -201,9 +201,9 @@
 					}
 				},
 				"escodegen": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-					"integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+					"version": "1.14.3",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+					"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
 					"requires": {
 						"esprima": "^4.0.1",
 						"estraverse": "^4.2.0",
@@ -374,9 +374,9 @@
 					"optional": true
 				},
 				"stackframe": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.1.tgz",
-					"integrity": "sha512-0PlYhdKh6AfFxRyK/v+6/k+/mMfyiEBbTM5L94D0ZytQnJ166wuwoTYLHFWGbs2dpA8Rgq763KGWmN1EQEYHRQ=="
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+					"integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",

--- a/packages/build/src/cli.js
+++ b/packages/build/src/cli.js
@@ -2,7 +2,6 @@ const fs = require("fs");
 const path = require("path");
 const { loadWebpackConfig } = require("./");
 const details = require("../package.json");
-const { buildStaticSite } = require("./util");
 const parseNodeArgs = require("parse-node-args");
 const rimraf = require("rimraf");
 const webpack = require("webpack");
@@ -88,10 +87,7 @@ exports.run = async options => {
     config.forEach(({ output: { path } }) => rimraf(path, done))
   );
 
-  compiler.run(async (err, stats) => {
+  compiler.run(err => {
     if (err) console.error(err);
-    if (options.static) {
-      await buildStaticSite(options, stats);
-    }
   });
 };

--- a/packages/build/src/files/server.js
+++ b/packages/build/src/files/server.js
@@ -3,7 +3,7 @@ import path from "path";
 import connectGzipStatic from "connect-gzip-static";
 
 const getRoute = global.GET_ROUTE;
-const modernBrowsers = global.MODERN_BROWSERS_REGEXP;
+const browserEnvs = global.BROWSER_ENVS;
 const PORT = process.env.PORT || global.PORT;
 const assetsMatch = /^\/assets\//;
 let gzipStatic;
@@ -37,7 +37,7 @@ const middleware =
         route.template.render(
           {
             $global: {
-              buildName: req.isModern ? "Browser-modern" : "Browser-legacy"
+              buildName: `Browser-${req.browserEnv}`
             },
             params: route.params,
             query,
@@ -60,7 +60,10 @@ http
         res.end("Not Found");
       });
     } else {
-      req.isModern = modernBrowsers.test(req.headers["user-agent"] || "");
+      const userAgent = req.headers["user-agent"] || "";
+      req.browserEnv = browserEnvs.find(
+        ({ test }) => !test || test.test(userAgent)
+      ).env;
       middleware(req, res, () => {
         res.end("Not Found");
       });

--- a/packages/serve/package-lock.json
+++ b/packages/serve/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"chalk": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-			"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"

--- a/packages/serve/src/cli.js
+++ b/packages/serve/src/cli.js
@@ -16,7 +16,7 @@ exports.parse = function parse(argv) {
         type: "boolean",
         description: "Show this help message"
       },
-      "--file -f *": {
+      "--entry *": {
         type: "string",
         description: "A marko file to serve"
       },
@@ -51,22 +51,16 @@ exports.parse = function parse(argv) {
         process.exit(0);
       }
 
-      if (!result.file) {
+      if (!result.entry) {
         this.printUsage();
         process.exit(1);
       }
 
-      const resolved = path.resolve(process.cwd(), result.file);
+      const resolved = path.resolve(process.cwd(), result.entry);
       if (fs.existsSync(resolved)) {
-        const stat = fs.statSync(resolved);
-        if (stat.isDirectory()) {
-          result.dir = resolved;
-          delete result.file;
-        } else {
-          result.file = resolved;
-        }
+        result.entry = resolved;
       } else {
-        console.warn("Unable to find file or directory: " + result.file);
+        console.warn("Unable to find file or directory: " + result.entry);
         process.exit(1);
       }
     })
@@ -93,8 +87,7 @@ exports.run = async options => {
   const local = `http://localhost:${port}`;
   const network = `http://${address.ip()}:${port}`;
   const location =
-    path.relative(process.cwd(), options.file || options.dir) ||
-    "the current directory";
+    path.relative(process.cwd(), options.entry) || "the current directory";
 
   const server = await serve({ ...options, port });
 

--- a/packages/serve/test/fixtures/custom-browserslist/.browserslistrc
+++ b/packages/serve/test/fixtures/custom-browserslist/.browserslistrc
@@ -1,0 +1,10 @@
+[production]
+> 1%
+ie 10
+
+[modern]
+last 1 chrome version
+last 1 firefox version
+
+[ssr]
+node 12

--- a/packages/serve/test/fixtures/custom-browserslist/build-expected.html
+++ b/packages/serve/test/fixtures/custom-browserslist/build-expected.html
@@ -1,0 +1,1 @@
+<body><h1>Hello Marko</h1></body>

--- a/packages/serve/test/fixtures/custom-browserslist/serve-expected.html
+++ b/packages/serve/test/fixtures/custom-browserslist/serve-expected.html
@@ -1,0 +1,1 @@
+<body><h1>Hello Marko</h1></body>

--- a/packages/serve/test/fixtures/custom-browserslist/target.marko
+++ b/packages/serve/test/fixtures/custom-browserslist/target.marko
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Document</title>
+</head>
+<body>
+  <h1>Hello Marko</h1>
+</body>
+</html>

--- a/packages/serve/test/fixtures/custom-webpack-config/build-expected.html
+++ b/packages/serve/test/fixtures/custom-webpack-config/build-expected.html
@@ -1,0 +1,1 @@
+<body><h1>Hello Marko</h1></body>

--- a/packages/serve/test/fixtures/custom-webpack-config/serve-expected.html
+++ b/packages/serve/test/fixtures/custom-webpack-config/serve-expected.html
@@ -1,0 +1,1 @@
+<body><h1>Hello Marko</h1></body>

--- a/packages/serve/test/fixtures/custom-webpack-config/target.marko
+++ b/packages/serve/test/fixtures/custom-webpack-config/target.marko
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Document</title>
+</head>
+<body>
+  <h1>Hello Marko</h1>
+</body>
+</html>

--- a/packages/serve/test/fixtures/custom-webpack-config/webpack.config.js
+++ b/packages/serve/test/fixtures/custom-webpack-config/webpack.config.js
@@ -1,0 +1,8 @@
+const path = require("path");
+const { configBuilder } = require("@marko/build");
+const { getServerConfig, getBrowserConfigs } = configBuilder({
+  entry: path.join(__dirname, "target.marko"),
+  production: process.env.NODE_ENV === "production"
+});
+
+module.exports = [...getBrowserConfigs(), getServerConfig()];

--- a/packages/serve/test/fixtures/custom-webpack-config/webpack.config.js
+++ b/packages/serve/test/fixtures/custom-webpack-config/webpack.config.js
@@ -1,7 +1,9 @@
 const path = require("path");
 const { configBuilder } = require("@marko/build");
+
 const { getServerConfig, getBrowserConfigs } = configBuilder({
   entry: path.join(__dirname, "target.marko"),
+  output: path.join(__dirname, "dist"),
   production: process.env.NODE_ENV === "production"
 });
 

--- a/packages/serve/test/index.test.js
+++ b/packages/serve/test/index.test.js
@@ -19,6 +19,7 @@ describe("scope(serve)", function() {
       const outputPath = resolve("dist");
 
       await new Promise((resolve, reject) => {
+        process.env.NODE_ENV = "production";
         webpack(
           loadWebpackConfig({ output: outputPath, ...options })
         ).run(err => (err ? reject(err) : resolve()));
@@ -46,7 +47,7 @@ describe("scope(serve)", function() {
 });
 
 function createTest(createServer) {
-  return ({ resolve, test, snapshot, mode }) => {
+  return ({ resolve, dir, test, snapshot, mode }) => {
     test(async () => {
       let browser, closeServer, backupPath, targetPath;
       try {
@@ -96,6 +97,12 @@ function createTest(createServer) {
           });
         }
       } finally {
+        delete process.env.NODE_ENV;
+        Object.keys(require.cache).forEach(key => {
+          if (key.startsWith(dir)) {
+            delete require.cache[key];
+          }
+        });
         if (browser) await browser.close();
         if (closeServer) await closeServer();
         if (backupPath) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->
This changes the programatic api for `@marko/build` and as such is a BREAKING CHANGE

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Allows using a custom `webpack.config.js` and provides helper functions to use the default base configs. Example:

```js
import path from "path";
import { configBuilder } from "@marko/build";
import MyPlugin from "my-plugin";
const { getServerConfig, getBrowserConfigs } = configBuilder({
  entry: path.join(__dirname, "target.marko"),
  production: process.env.NODE_ENV === "production"
});
module.exports = [
  ...getBrowserConfigs(config => {
    config.plugins.push(new MyPlugin());
    return config;
  }),
  getServerConfig(config => {
    config.plugins.push(new MyPlugin());
    return config;
  })
];
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
