### PR TITLE
feat: exclude components directory from served pages

### DIFF
--- a/packages/build/src/index.js
+++ b/packages/build/src/index.js
@@ -249,7 +249,11 @@ const configBuilder = (exports.configBuilder = ({
 
           if (ENTRY_IS_DIR) {
             parts.push(
-              await getRouterCode(entry, [BUILD_PATH, "**/node_modules"])
+              await getRouterCode(entry, [
+                BUILD_PATH,
+                "**/node_modules",
+                "**/components"
+              ])
             );
           } else if (entry.endsWith(".js")) {
             parts.push(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->

Excludes `components/` from files discovered to create pages.

## Motivation and Context

Including `components/` directories ends up creating many more entry points than likely intended, increasing the amount of work done by the builder.  

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
