### PR TITLE
Fix typo(?) in watchContext template literal

### DIFF
--- a/packages/build/src/util.js
+++ b/packages/build/src/util.js
@@ -64,7 +64,7 @@ const getRouterCode = async (cwd, ignore, production) => {
       /* webpackInclude: /\\.marko$/ */
       /* webpackExclude: /node_modules|components|build/ */
       /* webpackMode: "weak" */
-      ${JSON.stringify(cwd + path.sep)} + _
+      ${JSON.stringify(cwd + path.sep)}
     ));
   `;
 


### PR DESCRIPTION
Oops.

> 
> > DylanPiercey
> @polo I think you might be looking for this https://github.com/marko-js/cli/blob/master/packages/serve/src/index.js#L41
> GitHub
> marko-js/cli
> command-line tools for Marko. Contribute to marko-js/cli development by creating an account on GitHub.
> 
> The line you shared is used in order to force webpack to watch for Marko files that could be routed to.
> 
> By removing the + _  it will no longer discover new routes that are added while in dev mode.