### PR TITLE
feat(create): add support for package managers besides npm

### DIFF
--- a/packages/create-alias/package.json
+++ b/packages/create-alias/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "create-marko",
+  "description": "Create Marko projects",
+  "version": "6.0.2",
+  "bugs": "https://github.com/marko-js/cli/issues/new?template=Bug_report.md",
+  "dependencies": {
+    "@marko/create": "^6.0.2"
+  },
+  "files": ["dist/index.js"],
+  "homepage": "https://github.com/marko-js/cli/tree/master/packages/create",
+  "keywords": [
+    "create",
+    "demo",
+    "marko",
+    "util",
+    "utility"
+  ],
+  "license": "MIT",
+  "bin": {
+    "marko-create": "./dist/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marko-js/cli"
+  }
+}

--- a/packages/create-alias/src/index.js
+++ b/packages/create-alias/src/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("@marko/create/dist/bin");

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -24,14 +24,25 @@ Used to create a template Marko project in a specific directory.
 
 ## Example
 
-```bash
-# Creates a Marko project
-npx @marko/create
-```
+### npm
 
 ```bash
+# Creates a Marko project
+npm init @marko
 # Creates a project called "myapp" from the "webpack" example template
-npx @marko/create myapp --template webpack
+npm init @marko myapp --template webpack
+```
+
+### yarn
+
+```bash
+yarn create marko
+```
+
+### pnpm
+
+```
+pnpx @marko/create
 ```
 
 ## Options
@@ -48,6 +59,10 @@ npx @marko/create myapp --template webpack
     basic#next     # example branch
     webpack#v1.2.3 # repo release tag
     rollup#62e9fb1 # repo commit hash
+    ```
+- `--installer`: Override the package manager used to install dependencies. By default will determine from create command and fallback to `npm`.
+  - ```bash
+    marko-create --installer pnpm
     ```
 
 # API

--- a/packages/create/src/cli.js
+++ b/packages/create/src/cli.js
@@ -28,6 +28,11 @@ exports.parse = function parse(argv) {
         description:
           "An example from marko-js/examples or a git repo to use as the project template"
       },
+      "--installer -i": {
+        type: "string",
+        description:
+          "Override the package manager used to install dependencies. By default will determine from create command and fallback to npm."
+      },
       "--version -v": {
         type: "boolean",
         descrption: `print ${details.name} version`
@@ -55,7 +60,7 @@ exports.parse = function parse(argv) {
       "…from a github repo at a specific branch/tag/commit",
       `$0 my-new-app ${chalk.green.bold("--template user/repo#commit")}`
     )
-    .validate(function(result) {
+    .validate(function (result) {
       if (result.version) {
         console.log(`v${details.version}`);
         process.exit(0);
@@ -66,7 +71,7 @@ exports.parse = function parse(argv) {
         process.exit(0);
       }
     })
-    .onError(function(err) {
+    .onError(function (err) {
       this.printUsage();
       console.error(err);
       process.exit(1);


### PR DESCRIPTION
## Description

Adds support for a new `--installer` option for `@marko/create` which allows you to override the package manager used to install the dependencies. Also the default package manager is now automatically determined in cases where a package manager is used to run `@marko/create`, eg `yarn create marko` will use `yarn`.

Resolves #185

This PR also releases an alias package `marko-create` to support `yarn create`.

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
