### PR TITLE
fix(create): use a fallback git author if missing

### DIFF
--- a/packages/create/src/init-git-repo.js
+++ b/packages/create/src/init-git-repo.js
@@ -12,7 +12,17 @@ module.exports = async function initGitRepo(cwd, emitter) {
     emitter.emit("init");
     await execGit(cwd, ["init"]);
     await execGit(cwd, ["add", "."]);
-    await execGit(cwd, ["commit", "-m", `"${commitMessage}"`]);
+
+    if (!(await tryExecGit(cwd, ["commit", "-m", commitMessage]))) {
+      // Try manually specifying the author if the above failed.
+      await execGit(cwd, [
+        "commit",
+        "--author",
+        `"Marko JS <markojs.com>"`,
+        "-m",
+        commitMessage
+      ]);
+    }
   }
 };
 
@@ -29,7 +39,7 @@ function execGit(cwd, args) {
   return exec(cwd, "git", args);
 }
 
-let commitMessage = `initial commit from @marko/create
+let commitMessage = `"initial commit from @marko/create
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣤⣤⣤⣤⣤⣤⣤⣤⡀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣤⣤⣤⣤⣤⣤⣤⣤⡀⠀⠀⠀⢤⣤⣤⣤⣤⣤⣤⣤⡀
 ⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣆⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣆⠀⠀⠀⠹⣿⣿⣿⣿⣿⣿⣿⣆
 ⠀⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡀⠀⠀⠈⢿⣿⣿⣿⣿⣿⣿⣷⡀
@@ -44,4 +54,4 @@ let commitMessage = `initial commit from @marko/create
 ⠀⠀⠀⠀⠀⠀⠈⢿⣿⣿⣿⣿⣿⣿⣷⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣾⣿⣿⣿⣿⣿⣿⡿⠁⠀⠀⢀⣾⣿⣿⣿⣿⣿⣿⡿⠁
 ⠀⠀⠀⠀⠀⠀⠀⠀⠹⣿⣿⣿⣿⣿⣿⣿⣆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⣿⣿⣿⣿⠏⠀⠀⠀⣰⣿⣿⣿⣿⣿⣿⣿⠏
 ⠀⠀⠀⠀⠀⠀⠀⠀ ⠈⠛⠛⠛⠛⠛⠛⠛⠓⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠚⠛⠛⠛⠛⠛⠛⠛⠁⠀⠀⠀⠚⠛⠛⠛⠛⠛⠛⠛⠁
-`;
+"`;


### PR DESCRIPTION
## Description

Adds a fallback git author if missing to account for when users to not have `user.name` and `user.email` configured for git.

Resolves #184 

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

