### PR TITLE
fix(docs): npm init command

### DIFF
--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -28,9 +28,9 @@ Used to create a template Marko project in a specific directory.
 
 ```bash
 # Creates a Marko project
-npm init @marko
+npm init marko
 # Creates a project called "myapp" from the "webpack" example template
-npm init @marko myapp --template webpack
+npm init marko myapp -- --template webpack
 ```
 
 ### yarn


### PR DESCRIPTION
add command forwarding separator, remove `@` prefix

closes #213 

## Description

```console
❯ npm init marko -- anappyay --template tags-api
✔ Project created! To get started, run:

    cd anappyay
    npm run dev

❯ npm init marko anappyay2 -- --template tags-api
✔ Project created! To get started, run:

    cd anappyay2
    npm run dev

❯ npm init marko ./anappyay3 -- --template tags-api
✖ Invaid app name: ./anappyay3

Error: Invaid app name: ./anappyay3
```

```console
❯ npm search create-marko
NAME                      | DESCRIPTION          | AUTHOR          | DATE       | VERSION  | KEYWORDS
create-marko              | Create Marko…        | =ryansolid…     | 2021-05-04 | 6.1.1    | create demo marko util utility

~/src/wip/marko
❯ npm search @marko/create
NAME                      | DESCRIPTION          | AUTHOR          | DATE       | VERSION  | KEYWORDS
@marko/create             | Create Marko…        | =dylanpiercey…  | 2021-05-04 | 6.1.0    | create demo marko util utility
```