### PR TITLE
fix: allow testing of template whose name matches its parent directory

### DIFF
--- a/packages/test/src/util/loadTests.js
+++ b/packages/test/src/util/loadTests.js
@@ -15,7 +15,8 @@ function getRenderer(dir) {
   var paths = [
     path.join(dir, "index"),
     path.join(dir, "renderer"),
-    path.join(dir, "template.marko")
+    path.join(dir, "template.marko"),
+    path.join(dir, path.basename(dir))
   ];
 
   for (var i = 0; i < paths.length; i++) {


### PR DESCRIPTION
Marko templates can be named the same as their parent directory [according to the docs](https://markojs.com/docs/custom-tags/#tag-directories). @marko/test doesn't look for templates with the same name as their parent directory. This PR fixes that


## Description

I added an entry for same-named templates to the list of paths returned by `getRenderer`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
IMHO Allowing same-named templates is a good feature, it avoids having a bunch of editor tabs all called "index.marko"

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
  - Marko allows same-named templates. There's no documentation on why the test loader doesn't load same-named templates (so I'd assumed that it would). This feels more like a fix than a new feature.
- [ ] I have added tests to cover my changes.
  - I'm happy to follow whatever test pattern you'd like. I didn't find one to follow for the test loader.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->

If the empty documentation and test checkboxes are a deal-breaker I'm happy to do the work (but I may need some guidance please)

This probably isn't the most important issue but I lost some time because @marko/test didn't work the way I'd expected it to. 

Thank you!