### PR TITLE
chore: allow esbuild build scripts to fix fresh-clone install

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 packages:
   - "packages/*"
+
+# esbuild (an optional peer of vite, pulled in by vitest) ships a postinstall
+# that pnpm blocks by default. Allow it so fresh clones don't error with
+# ERR_PNPM_IGNORED_BUILDS.
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
A fresh clone's `pnpm install` fails with `ERR_PNPM_IGNORED_BUILDS: esbuild`. esbuild is an optional peer of `vite` (pulled in by `vitest`) and ships a postinstall that pnpm 10+ blocks by default, erroring on first install until it's approved.

Whitelists it via `onlyBuiltDependencies` in `pnpm-workspace.yaml` (what `pnpm approve-builds` writes) so clones install cleanly.