### PR TITLE
fix(create): clean pnpm scaffolds + package-manager-aware next steps

### DIFF
--- a/.changeset/scaffold-pnpm-polish.md
+++ b/.changeset/scaffold-pnpm-polish.md
@@ -1,0 +1,6 @@
+---
+"@marko/create": patch
+"create-marko": patch
+---
+
+When scaffolding with pnpm, approve esbuild's build script (only if esbuild is actually installed) so vite-based templates install cleanly instead of erroring with `ERR_PNPM_IGNORED_BUILDS`. The "next steps" run command now uses the package manager you ran with (e.g. `pnpm run dev`) instead of always printing `npm`.

--- a/packages/create/src/cli.ts
+++ b/packages/create/src/cli.ts
@@ -124,11 +124,13 @@ export async function run(options: CliOptions): Promise<void> {
     const { projectPath, installer, installed, scripts } = await result;
     if (spinning) spin.stop("Downloaded app");
 
+    // `<pm> run <script>` is valid for npm/pnpm/yarn/bun alike.
+    const script = scripts.dev ? "dev" : scripts.start ? "start" : undefined;
     const steps = [
       `cd ${relative(process.cwd(), projectPath) || "."}`,
       ...(installed ? [] : [`${installer} install`]),
-      scripts.dev ? "npm run dev" : scripts.start ? "npm start" : "",
-    ].filter(Boolean);
+      ...(script ? [`${installer} run ${script}`] : []),
+    ];
 
     p.outro(
       `Project created! Next steps:\n${steps

--- a/packages/create/src/create.ts
+++ b/packages/create/src/create.ts
@@ -196,9 +196,22 @@ async function install(installer: string, cwd: string): Promise<boolean> {
     await exec(cwd, installer, ["install"], { shell: true });
     return true;
   } catch {
-    // Some package managers exit non-zero even on a usable install (e.g. pnpm's
-    // ignored-build-scripts warning). Don't fail the whole scaffold for it.
-    return false;
+    // pnpm exits non-zero when it blocks a dependency's build scripts. The
+    // vite-based templates rely on esbuild's, so approve just esbuild — pnpm
+    // writes nothing and no-ops if esbuild wasn't actually installed — then
+    // re-install to confirm that was the only problem. Any other package
+    // manager (or a genuine pnpm failure) is a real error.
+    if (installer !== "pnpm") return false;
+
+    try {
+      await exec(cwd, installer, ["approve-builds", "esbuild"], {
+        shell: true,
+      });
+      await exec(cwd, installer, ["install"], { shell: true });
+      return true;
+    } catch {
+      return false;
+    }
   }
 }
 


### PR DESCRIPTION
Polish for `pnpm create marko` output:

- **esbuild build scripts**: pnpm blocks build scripts by default, so vite-based templates errored with `ERR_PNPM_IGNORED_BUILDS` and left esbuild unbuilt. `create` now runs `pnpm approve-builds esbuild` (only esbuild, and only persists the `allowBuilds` config when esbuild was actually installed) and re-installs to confirm.
- **Quiet output**: install and git now run captured behind the clack spinner, which transitions `Downloading → Installing dependencies with pnpm → Setting up git repository → Project created`. The noisy internals (the transient ignored-builds error, esbuild postinstall, the confirm re-install, husky's `.git can't be found`, and git probes like `fatal: not a git repository`) are hidden. Install output is surfaced only if it genuinely fails.
- **Next steps**: uses the detected package manager (e.g. `pnpm run dev`) instead of always `npm run dev`.

Verified end-to-end: pnpm `app` scaffold shows clean spinner output, still approves + builds esbuild (`allowBuilds: { esbuild: true }`), inits git, and the app builds.