### PR TITLE
fix(create): remove duplicated "Project created" line

### DIFF
--- a/.changeset/dedupe-created-message.md
+++ b/.changeset/dedupe-created-message.md
@@ -1,0 +1,6 @@
+---
+"@marko/create": patch
+"create-marko": patch
+---
+
+Remove the duplicated "Project created" line at the end of the scaffold — the spinner's final message and the closing message both said it. The spinner now ends with "Project created" and the closing line starts the "Next steps".

--- a/packages/create/src/cli.ts
+++ b/packages/create/src/cli.ts
@@ -132,9 +132,7 @@ export async function run(options: CliOptions): Promise<void> {
     ];
 
     p.outro(
-      `Project created! Next steps:\n${steps
-        .map((step) => color.cyan(`  ${step}`))
-        .join("\n")}`,
+      `Next steps:\n${steps.map((step) => color.cyan(`  ${step}`)).join("\n")}`,
     );
   } catch (err) {
     spin.stop("Failed to create project", 1);


### PR DESCRIPTION
The scaffold printed "Project created" twice — once as the spinner's final message and again at the start of the closing line. The closing line now just leads with "Next steps:":

```
◇  Project created
│
└  Next steps:
    cd example
    pnpm run dev
```