### PR TITLE
feat(create): CLI improvements (name validation, flags, GitHub auth, agent-clean output)

### DIFF
--- a/.changeset/create-improvements.md
+++ b/.changeset/create-improvements.md
@@ -1,0 +1,6 @@
+---
+"@marko/create": minor
+"create-marko": minor
+---
+
+CLI improvements: validate the project name and derive a valid npm package name from it (e.g. `My App` → `my-app`); add `--no-install` and `--no-git`; hide the legacy `*-marko-5` examples from the interactive list (still usable via `--template`); authenticate GitHub requests with `GITHUB_TOKEN`/`GH_TOKEN` when set (higher rate limits and private templates), with clearer rate-limit errors; use plain step output instead of an animated spinner under CI/agents/piped output; and fail clearly on a missing template (and surface the underlying cause) instead of scaffolding an empty project.

--- a/packages/create/src/__tests__/env.test.ts
+++ b/packages/create/src/__tests__/env.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { detectInstaller, githubToken } from "../env.js";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("detectInstaller", () => {
+  it("reads the package manager from npm_config_user_agent", () => {
+    vi.stubEnv("npm_config_user_agent", "pnpm/9.0.0 npm/? node/v22 linux x64");
+    expect(detectInstaller()).toBe("pnpm");
+  });
+
+  it("falls back to npm", () => {
+    vi.stubEnv("npm_config_user_agent", "");
+    expect(detectInstaller()).toBe("npm");
+  });
+});
+
+describe("githubToken", () => {
+  it("prefers GITHUB_TOKEN, then GH_TOKEN", () => {
+    vi.stubEnv("GH_TOKEN", "gh");
+    vi.stubEnv("GITHUB_TOKEN", "primary");
+    expect(githubToken()).toBe("primary");
+
+    vi.stubEnv("GITHUB_TOKEN", "");
+    expect(githubToken()).toBe("gh");
+  });
+});

--- a/packages/create/src/__tests__/name.test.ts
+++ b/packages/create/src/__tests__/name.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidProjectName, toPackageName } from "../name.js";
+
+describe("toPackageName", () => {
+  it("lowercases and dashes spaces", () => {
+    expect(toPackageName("My App")).toBe("my-app");
+  });
+
+  it("keeps an already-valid name", () => {
+    expect(toPackageName("basic")).toBe("basic");
+  });
+
+  it("strips leading dots and underscores", () => {
+    expect(toPackageName("._foo")).toBe("foo");
+  });
+
+  it("falls back to 'app' when nothing usable remains", () => {
+    expect(toPackageName("!!!")).toBe("app");
+  });
+});
+
+describe("isValidProjectName", () => {
+  it("accepts a simple name", () => {
+    expect(isValidProjectName("my-app")).toBe(true);
+  });
+
+  it("rejects empty and slashed names", () => {
+    expect(isValidProjectName("   ")).toBe(false);
+    expect(isValidProjectName("a/b")).toBe(false);
+    expect(isValidProjectName("a\\b")).toBe(false);
+  });
+});

--- a/packages/create/src/__tests__/parse.test.ts
+++ b/packages/create/src/__tests__/parse.test.ts
@@ -29,4 +29,16 @@ describe("parse", () => {
     const options = parse(["-n", "example", "-y"]);
     expect(options.yes).toBe(true);
   });
+
+  it("parses --no-install and --no-git as opt-outs", () => {
+    const options = parse(["-n", "example", "--no-install", "--no-git"]);
+    expect(options.install).toBe(false);
+    expect(options.git).toBe(false);
+  });
+
+  it("leaves install/git undefined by default", () => {
+    const options = parse(["-n", "example"]);
+    expect(options.install).toBeUndefined();
+    expect(options.git).toBeUndefined();
+  });
 });

--- a/packages/create/src/__tests__/template.test.ts
+++ b/packages/create/src/__tests__/template.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTemplate } from "../create.js";
+
+describe("parseTemplate", () => {
+  it("maps a named example to marko-js/examples", () => {
+    expect(parseTemplate("basic")).toEqual({
+      input: "github:marko-js/examples/examples/basic",
+      repo: "marko-js/examples",
+      ref: undefined,
+    });
+  });
+
+  it("carries a ref on a named example", () => {
+    expect(parseTemplate("basic#next")).toMatchObject({
+      input: "github:marko-js/examples/examples/basic",
+      ref: "next",
+    });
+  });
+
+  it("maps a user/repo git template", () => {
+    expect(parseTemplate("user/repo")).toEqual({
+      input: "github:user/repo",
+      repo: "user/repo",
+      ref: undefined,
+    });
+  });
+
+  it("supports a subdirectory and ref", () => {
+    expect(parseTemplate("user/repo/packages/app#v1")).toMatchObject({
+      input: "github:user/repo/packages/app",
+      repo: "user/repo",
+      ref: "v1",
+    });
+  });
+});

--- a/packages/create/src/cli.ts
+++ b/packages/create/src/cli.ts
@@ -6,6 +6,7 @@ import color from "picocolors";
 
 import { createProject, DEFAULT_TEMPLATE, getExamples } from "./create.js";
 import { isAgent, isCI } from "./env.js";
+import { isValidProjectName } from "./name.js";
 import { version } from "./pkg.js";
 
 export interface CliOptions {
@@ -14,6 +15,8 @@ export interface CliOptions {
   dir?: string;
   installer?: string;
   yes?: boolean;
+  install?: boolean;
+  git?: boolean;
   help?: boolean;
   version?: boolean;
 }
@@ -28,6 +31,8 @@ ${color.bold("Options:")}
   -d, --dir        Directory to create the app in (default: current directory)
   -i, --installer  Package manager to install with (default: detected)
   -y, --yes        Skip prompts and accept defaults (implied under CI and agents)
+      --no-install Skip installing dependencies
+      --no-git     Skip initializing a git repository
   -v, --version    Print the version
   -h, --help       Show this help message`;
 
@@ -41,12 +46,24 @@ export function parse(argv: string[]): CliOptions {
       dir: { type: "string", short: "d" },
       installer: { type: "string", short: "i" },
       yes: { type: "boolean", short: "y" },
+      "no-install": { type: "boolean" },
+      "no-git": { type: "boolean" },
       help: { type: "boolean", short: "h" },
       version: { type: "boolean", short: "v" },
     },
   });
 
-  return { ...values, name: values.name ?? positionals[0] };
+  return {
+    name: values.name ?? positionals[0],
+    template: values.template,
+    dir: values.dir,
+    installer: values.installer,
+    yes: values.yes,
+    install: values["no-install"] ? false : undefined,
+    git: values["no-git"] ? false : undefined,
+    help: values.help,
+    version: values.version,
+  };
 }
 
 export async function run(options: CliOptions): Promise<void> {
@@ -87,9 +104,14 @@ export async function run(options: CliOptions): Promise<void> {
       message: "What is your project named?",
       placeholder: "my-app",
       defaultValue: "my-app",
+      validate: (value) => {
+        if (value && !isValidProjectName(value)) {
+          return "Name can't contain slashes.";
+        }
+      },
     });
     if (p.isCancel(answer)) return cancelled();
-    name = answer || "my-app";
+    name = answer.trim() || "my-app";
   }
 
   if (!template) {
@@ -97,25 +119,34 @@ export async function run(options: CliOptions): Promise<void> {
     if (template === undefined) return cancelled();
   }
 
-  const spin = p.spinner();
-  spin.start("Setting up project");
+  // Skip the animated spinner when nothing is watching a terminal (agents/CI/
+  // piped output) — it would otherwise spam frames into captured logs.
+  const plain = !process.stdout.isTTY || isAgent() || isCI();
+  const spin = plain ? undefined : p.spinner();
+  spin?.start("Setting up project");
+  const step = (message: string) =>
+    spin ? spin.message(message) : p.log.step(message);
+
+  let installFailed = false;
   let installLog = "";
 
   const result = createProject({ ...options, name, template });
-  result.on("download", () => spin.message("Downloading app"));
+  result.on("download", () => step("Downloading app"));
   result.on("install", (installer: string) =>
-    spin.message(`Installing dependencies with ${installer}`),
+    step(`Installing dependencies with ${installer}`),
   );
   result.on("install-error", (_installer: string, log?: string) => {
+    installFailed = true;
     installLog = log ?? "";
   });
-  result.on("init", () => spin.message("Setting up git repository"));
+  result.on("init", () => step("Setting up git repository"));
 
   try {
     const { projectPath, installer, installed, scripts } = await result;
-    spin.stop("Project created");
+    if (spin) spin.stop("Project created");
+    else p.log.success("Project created");
 
-    if (!installed) {
+    if (installFailed) {
       p.log.warn(
         `${color.cyan(`${installer} install`)} did not finish cleanly — you ` +
           "may need to run it yourself.",
@@ -125,8 +156,9 @@ export async function run(options: CliOptions): Promise<void> {
 
     // `<pm> run <script>` is valid for npm/pnpm/yarn/bun alike.
     const script = scripts.dev ? "dev" : scripts.start ? "start" : undefined;
+    const dir = relative(process.cwd(), projectPath) || ".";
     const steps = [
-      `cd ${relative(process.cwd(), projectPath) || "."}`,
+      `cd ${/\s/.test(dir) ? `"${dir}"` : dir}`,
       ...(installed ? [] : [`${installer} install`]),
       ...(script ? [`${installer} run ${script}`] : []),
     ];
@@ -135,8 +167,13 @@ export async function run(options: CliOptions): Promise<void> {
       `Next steps:\n${steps.map((step) => color.cyan(`  ${step}`)).join("\n")}`,
     );
   } catch (err) {
-    spin.stop("Failed to create project", 1);
-    p.cancel((err as Error).message);
+    if (spin) spin.stop("Failed to create project", 1);
+    else p.log.error("Failed to create project");
+
+    const error = err as Error & { cause?: unknown };
+    const detail =
+      error.cause instanceof Error ? `\n${error.cause.message}` : "";
+    p.cancel(error.message + detail);
     process.exitCode = 1;
   }
 }
@@ -161,7 +198,11 @@ async function promptTemplate(): Promise<string | undefined> {
 
   const spin = p.spinner();
   spin.start("Loading examples");
-  const examples = await getExamples();
+  // Hide the legacy Marko 5 examples from the browse list; they can still be
+  // used explicitly via `--template <name>-marko-5`.
+  const examples = (await getExamples()).filter(
+    ({ name }) => !name.endsWith("-marko-5"),
+  );
   spin.stop("Loaded examples");
 
   const example = await p.select({

--- a/packages/create/src/create.ts
+++ b/packages/create/src/create.ts
@@ -11,9 +11,10 @@ import { join, resolve } from "node:path";
 
 import { downloadTemplate } from "giget";
 
-import { detectInstaller } from "./env.js";
+import { detectInstaller, githubToken } from "./env.js";
 import { exec, type ExecError } from "./exec.js";
 import { initGitRepo } from "./git.js";
+import { toPackageName } from "./name.js";
 
 export const DEFAULT_TEMPLATE = "basic";
 const EXAMPLES_REPO = "marko-js/examples";
@@ -28,6 +29,10 @@ export interface CreateOptions {
   template?: string;
   /** Package manager used to install dependencies. */
   installer?: string;
+  /** Install dependencies after downloading. Defaults to `true`. */
+  install?: boolean;
+  /** Initialize a git repository. Defaults to `true`. */
+  git?: boolean;
 }
 
 export interface CreateResult {
@@ -75,13 +80,25 @@ async function create(
   emitter.emit("download");
   await downloadRepo(template, projectPath);
 
-  const { scripts } = await rewritePackageJson(projectPath, name);
+  const { hasPackageJson, scripts } = await rewritePackageJson(
+    projectPath,
+    name,
+  );
 
-  emitter.emit("install", installer);
-  const { installed, log } = await install(installer, projectPath);
-  if (!installed) emitter.emit("install-error", installer, log);
+  // Nothing to install when the template isn't a node project.
+  let installed = true;
+  if (hasPackageJson) {
+    if (options.install === false) {
+      installed = false; // skipped by the user; surface it in the next steps
+    } else {
+      emitter.emit("install", installer);
+      const result = await install(installer, projectPath);
+      installed = result.installed;
+      if (!installed) emitter.emit("install-error", installer, result.log);
+    }
+  }
 
-  await initGitRepo(projectPath, emitter);
+  if (options.git !== false) await initGitRepo(projectPath, emitter);
 
   return { projectPath, installer, installed, scripts };
 }
@@ -92,7 +109,7 @@ export async function getExamples(): Promise<Example[]> {
   const ref = await resolveDefaultBranch(EXAMPLES_REPO);
   const { dir } = await downloadTemplate(
     `github:${EXAMPLES_REPO}/${EXAMPLES_DIR}#${ref}`,
-    { dir: join(cwd, EXAMPLES_DIR), force: true },
+    { dir: join(cwd, EXAMPLES_DIR), force: true, auth: githubToken() },
   );
   const entries = await readdir(dir, { withFileTypes: true });
 
@@ -107,7 +124,7 @@ export async function getExamples(): Promise<Example[]> {
   );
 }
 
-interface ParsedTemplate {
+export interface ParsedTemplate {
   /** The giget input, minus the ref. */
   input: string;
   /** `owner/repo` the template lives in. */
@@ -117,7 +134,7 @@ interface ParsedTemplate {
 }
 
 /** Map a template reference to a giget input + source repo. */
-function parseTemplate(template: string): ParsedTemplate {
+export function parseTemplate(template: string): ParsedTemplate {
   const [source, ref] = template.split("#");
 
   if (source.includes("/")) {
@@ -149,23 +166,49 @@ async function downloadRepo(
     // giget defaults an unspecified ref to `main`; resolve the repo's actual
     // default branch so templates on `master` (or anything else) still work.
     const resolvedRef = ref ?? (await resolveDefaultBranch(repo));
-    await downloadTemplate(`${input}#${resolvedRef}`, { dir: projectPath });
+    await downloadTemplate(`${input}#${resolvedRef}`, {
+      dir: projectPath,
+      auth: githubToken(),
+    });
   } catch (cause) {
     throw new Error(`Could not download the "${template}" template.`, {
       cause,
     });
   }
+
+  // giget silently produces an empty directory when the path doesn't exist;
+  // treat that as a missing template rather than scaffolding nothing.
+  const files = await readdir(projectPath).catch(() => []);
+  if (files.length === 0) {
+    throw new Error(`Template "${template}" was not found.`);
+  }
 }
 
 /** Look up a GitHub repo's default branch. */
 async function resolveDefaultBranch(repo: string): Promise<string> {
+  const token = githubToken();
   const response = await fetch(`https://api.github.com/repos/${repo}`, {
-    headers: { "user-agent": "create-marko" },
+    headers: {
+      "user-agent": "create-marko",
+      accept: "application/vnd.github+json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
   });
 
   if (!response.ok) {
+    if (
+      (response.status === 403 || response.status === 429) &&
+      response.headers.get("x-ratelimit-remaining") === "0"
+    ) {
+      throw new Error(
+        "Hit GitHub's API rate limit. Set GITHUB_TOKEN to raise it, or try again later.",
+      );
+    }
+    if (response.status === 404) {
+      throw new Error(`GitHub repository "${repo}" not found.`);
+    }
     throw new Error(
-      `GitHub repository "${repo}" not found (${response.status}).`,
+      `GitHub request for "${repo}" failed (${response.status}).`,
     );
   }
 
@@ -178,17 +221,24 @@ async function resolveDefaultBranch(repo: string): Promise<string> {
 async function rewritePackageJson(
   projectPath: string,
   name: string,
-): Promise<{ scripts: Record<string, string> }> {
+): Promise<{ hasPackageJson: boolean; scripts: Record<string, string> }> {
   const packagePath = join(projectPath, "package.json");
-  const pkg = JSON.parse(await readFile(packagePath, "utf8"));
 
-  pkg.name = name;
+  let pkg;
+  try {
+    pkg = JSON.parse(await readFile(packagePath, "utf8"));
+  } catch {
+    // Not a node project (or no readable package.json) — nothing to rewrite.
+    return { hasPackageJson: false, scripts: {} };
+  }
+
+  pkg.name = toPackageName(name);
   pkg.version = "1.0.0";
   pkg.private = true;
 
   await writeFile(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
 
-  return { scripts: pkg.scripts ?? {} };
+  return { hasPackageJson: true, scripts: pkg.scripts ?? {} };
 }
 
 async function install(

--- a/packages/create/src/env.ts
+++ b/packages/create/src/env.ts
@@ -7,6 +7,10 @@ export const isAgent = (): boolean =>
 
 export const isCI = (): boolean => Boolean(process.env.CI);
 
+/** A GitHub token from the environment, if one is set. */
+export const githubToken = (): string | undefined =>
+  process.env.GITHUB_TOKEN || process.env.GH_TOKEN || undefined;
+
 /**
  * Detect the package manager used to invoke the command (via
  * `npm_config_user_agent`), falling back to `npm`.

--- a/packages/create/src/name.ts
+++ b/packages/create/src/name.ts
@@ -1,0 +1,21 @@
+/** Whether a project name is usable as a target folder. */
+export function isValidProjectName(name: string): boolean {
+  return name.trim().length > 0 && !/[\\/]/.test(name);
+}
+
+/**
+ * Derive a valid npm package name from a project name — lowercased, spaces and
+ * unsupported characters replaced with `-`. Falls back to `app` if nothing
+ * usable remains.
+ */
+export function toPackageName(name: string): string {
+  return (
+    name
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/^[._]+/, "")
+      .replace(/[^a-z\d\-~]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "app"
+  );
+}


### PR DESCRIPTION
A batch of create-CLI improvements:

- **Name handling**: validate the project name in the prompt and derive a valid npm package name from it (`My App` → `my-app`); quote `cd` paths that contain spaces.
- **Agent/CI output**: skip the animated clack spinner when output isn't a TTY (or under CI/agents) — it was spamming spinner frames into captured logs; use plain step lines instead.
- **Hide legacy examples**: the `*-marko-5` examples no longer clutter the interactive browse list (still usable via `--template <name>-marko-5`).
- **GitHub auth**: send `GITHUB_TOKEN`/`GH_TOKEN` on the default-branch lookup and to giget (raises the 60/hr anon rate limit and enables private `user/repo` templates); distinguish rate-limit (403/429) from not-found (404).
- **Surface failures**: include the wrapped cause on download errors, and error on a missing/empty template instead of silently scaffolding an empty project.
- **New flags**: `--no-install` and `--no-git`. Templates without a `package.json` are handled gracefully (skip install).
- **Tests**: added unit tests for `parseTemplate`, `toPackageName`/`isValidProjectName`, `detectInstaller`/`githubToken`, and the new flags (20 total).

Verified end-to-end: plain agent output, name sanitization, `--no-install`/`--no-git`, missing-template error, and a full pnpm `app` scaffold (still approves esbuild, clean output).